### PR TITLE
Fixing pauseAll

### DIFF
--- a/lib/sonos-http-api.js
+++ b/lib/sonos-http-api.js
@@ -12,7 +12,7 @@ function HttpAPI(discovery, port, presets) {
   function pauseAll() {
     pauseState = {};
     discovery.getZones().forEach(function (zone) {
-      pauseState[zone.uuid] = zone.coordinator.state.currentState;
+      pauseState[zone.uuid] = zone.coordinator.state.zoneState;
       if (pauseState[zone.uuid] == "PLAYING") {
         var player = discovery.getPlayerByUUID(zone.uuid);
         player.pause();


### PR DESCRIPTION
Fixed pauseAll by getting zone.coordinator.state.zoneState instead of (non existing) zone.coordinator.state.currentState
