### PR TITLE
Add Content-Length to the API response headers

### DIFF
--- a/lib/sonos-http-api.js
+++ b/lib/sonos-http-api.js
@@ -103,7 +103,7 @@ function HttpAPI(discovery, settings, presets) {
     var response = handleAction(opt, function (response) {
       if (response) {
         var jsonResponse = JSON.stringify(response);
-        res.setHeader("Content-Length", Buffer.byteLength(jsonResponse));
+        res.setHeader('Content-Length', Buffer.byteLength(jsonResponse));
         res.write(new Buffer(jsonResponse));
       }
       res.end();


### PR DESCRIPTION
I had an application that was having issues with these responses because they didn't include a Content-Length header in the response.

I've changed the code to use implicit headers using `setHeader()` instead of `writeHead()` and added code to set the `Content-Length` header after we have the JSON response.
