### PR TITLE
Blacklist: skip tracks based on rules

### DIFF
--- a/lib/blacklist.js
+++ b/lib/blacklist.js
@@ -1,0 +1,35 @@
+var blacklist = [
+  // { artist: 'Any song from this artist' },
+  // { artist: 'Songs from this artist', album: 'Only from this album' },
+  // { album: 'Any song from an album named like this - no matter the artist' },
+  // { title: 'This track title - no matter album or artist' },
+  // { title: 'This song', artist: 'Only if from this artist' }
+]
+
+var ruleApplies = function(rule, track) {
+  for(key in rule) {
+    if(track[key] != rule[key]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+var isBlacklisted = function(track) {
+  for(ruleIndex in blacklist) {
+    var rule = blacklist[ruleIndex];
+    if(ruleApplies(rule, track)) {
+      console.log("Current track " + JSON.stringify(track) + " matches blaclisted rule " + JSON.stringify(rule));
+      return true;
+    }
+  }
+}
+
+module.exports = function(_discovery) {
+  return function(player) {
+    var discovery = _discovery;
+    if(isBlacklisted(player.state.currentTrack)) {
+      discovery.getPlayerByUUID(player.coordinator).nextTrack();
+    }
+  }
+}

--- a/lib/sonos-http-api.js
+++ b/lib/sonos-http-api.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var requireFu = require('require-fu');
+var Blacklist = require('./blacklist');
 
 function HttpAPI(discovery, settings) {
 
@@ -18,6 +19,10 @@ function HttpAPI(discovery, settings) {
   };
 
   this.discovery = discovery;
+
+  var blacklist = new Blacklist(discovery);
+
+  discovery.on('transport-state', blacklist);
 
   // this handles registering of all actions
   this.registerAction = function (action, handler) {


### PR DESCRIPTION
Spotify Radios doesn't seem to be _that_ refined for local (_Argentinian_) artists, so they are hard to listen - you get a really weird mix of bands on the playlist. So, with this, you can define which artists/albums/tracks you don't want to hear, and so you are able to hear Radios :)


Skip to the next song of the player if the current one matches any of rules defined in the blacklist.
For the time being, the rules have to be defined in the source code, and the blacklist doesn't check the next track to try to avoid it.

But it works :D