### PR TITLE
Added docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+###############################################
+# Debian with sonos http api
+###############################################
+
+# Using latest debian image as base (ubuntu is a fat cow)
+FROM debian
+
+MAINTAINER Erik-jan Riemers
+
+RUN apt-get update
+RUN apt-get install -y nodejs npm git git-core
+
+ADD dockerstart.sh /tmp/
+RUN chmod +x /tmp/dockerstart.sh
+EXPOSE 5005 3500 1901
+CMD ./tmp/dockerstart.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@
 ###############################################
 
 # Using latest debian image as base (ubuntu is a fat cow)
-FROM debian
+FROM node:slim
 
 MAINTAINER Erik-jan Riemers
 
 RUN apt-get update
-RUN apt-get install -y nodejs npm git git-core
+RUN apt-get -y install npm git git-core
 
 ADD dockerstart.sh /tmp/
 RUN chmod +x /tmp/dockerstart.sh

--- a/README.md
+++ b/README.md
@@ -198,6 +198,17 @@ Example:
 
 Sayall will group all players, set 20% volume and then try and restore everything as the way it where. Please try it out, it will probably contain glitches but please report detailed descriptions on what the problem is (starting state, error that occurs, and the final state of your system).
 
+Docker
+-------
+
+A docker file is included, make sure that if you use this that you start up your container with "--net=host" example:
+
+```
+docker run --net=host -d <your container/image name>
+```
+
+More information for docker https://docs.docker.com
+
 Webhook
 -------
 
@@ -211,7 +222,7 @@ Since 0.17.x there is now support for a web hook. If you add a setting in settin
 }
 ```
 
-Every state change and tpolopogy change will be posted (method POST) to that URL, as JSON. The following data structure will be sent:
+Every state change and topology change will be posted (method POST) to that URL, as JSON. The following data structure will be sent:
 
 ```
 {

--- a/dockerstart.sh
+++ b/dockerstart.sh
@@ -3,7 +3,6 @@ cd /sonos
 
 # try to remove the repo if it already exists
 rm -rf node-sonos-http-api; true
-ln -s /usr/bin/nodejs /usr/bin/node
 
 git clone https://github.com/jishi/node-sonos-http-api
 

--- a/dockerstart.sh
+++ b/dockerstart.sh
@@ -1,0 +1,16 @@
+mkdir -p /sonos
+cd /sonos
+
+# try to remove the repo if it already exists
+rm -rf node-sonos-http-api; true
+ln -s /usr/bin/nodejs /usr/bin/node
+
+git clone https://github.com/jishi/node-sonos-http-api
+
+cd node-sonos-http-api
+
+npm install
+npm install -g pm2
+
+pm2 start server.js -x --name "http-api"
+pm2 logs

--- a/lib/sonos-http-api.js
+++ b/lib/sonos-http-api.js
@@ -91,7 +91,7 @@ function HttpAPI(discovery, settings) {
       uri: settings.webhook,
       json: true,
       body: {
-        type,
+        type: type,
         data: data
       }
     })


### PR DESCRIPTION
Created the docker file + docker.sh , so everytime the docker is restarted it will just grab a fresh copy of the github repo. I would suggest that you make a entry on the docker hub for this. I've got one https://hub.docker.com/r/riemers/sonos_http_api/ but if you add one, then people could just grab it from there (as in you can maintain it). With my hub account the docker command would be: 
```
docker run --net=host -d riemers/sonos_http_api
```
Which makes it easier for people to grab it from all kinds of tools. If you want it differently, don't hesitate to ask/suggest ;)