### PR TITLE
Return list of presets and update README for preset and sleep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ cache
 settings.json
 static/tts
 .idea
+.ntvs_analysis.dat
+obj/
+*.njsproj
+*.sln

--- a/README.md
+++ b/README.md
@@ -136,11 +136,12 @@ Example preset (state and uri are optional):
 	  "uri": "x-rincon-stream:RINCON_0000000000001400",
 	  "playMode": "SHUFFLE",
 	  "pauseOthers": true
+	  "sleep": "01:00:00"
 	}
 
 The first player listed in the example, "room1", will become the coordinator. It will loose it's queue when ungrouped but eventually that will be fixed in the future. Playmodes are the ones defined in UPnP, which are: NORMAL, REPEAT_ALL, SHUFFLE_NOREPEAT, SHUFFLE
 Favorite will have precedence over a uri. Playmode requires 0.4.2 of sonos-discovery to work.
-pauseOthers will pause all zones before applying the preset, effectively muting your system.
+pauseOthers will pause all zones before applying the preset, effectively muting your system.  sleep is an optional value that enables the sleep timer and supports the 'HH:MM:SS' format.
 
 preset.json
 -----------

--- a/lib/actions/preset.js
+++ b/lib/actions/preset.js
@@ -1,19 +1,28 @@
 var fs = require('fs');
 var presets = {};
 
-function presetsAction(player, values) {
+function presetsAction(player, values, callback) {
   var value = decodeURIComponent(values[0]);
   if (value.startsWith('{'))
     var preset = JSON.parse(value);
   else
     var preset = presets[value];
-
-  if (preset)
+  
+  if (preset) {
     player.discovery.applyPreset(preset, function (err, result) {
       if (err) {
         console.error(err, result)
       }
     });
+  } else {
+    var simplePresets = [];
+    for (var key in presets) {
+      if (presets.hasOwnProperty(key)) {
+        simplePresets.push(key);
+      }
+    }
+    callback(simplePresets);
+  }
 }
 
 function initPresets(api) {


### PR DESCRIPTION
Currently if you don't specify a preset name it will now return the list of presets.  An alternative would be to add a presets command that does this and not overload preset.