### PR TITLE
added support for https and basic auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ static/tts
 obj/
 *.njsproj
 *.sln
+.DS_Store
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "node-static": "0.7.x",
     "request-promise": "^1.0.2",
     "require-fu": "1.0.x",
+    "basic-auth": "1.0.x",
     "sonos-discovery": "https://github.com/jishi/node-sonos-discovery/archive/0.15.6.tar.gz"
   },
   "engine": "node 4.x.x",

--- a/server.js
+++ b/server.js
@@ -89,5 +89,5 @@ var requestListener = function (req, res) {
 var server = (settings.https ? https.createServer(options, requestListener) : http.createServer(requestListener));
 
 server.listen(settings.port, function () {
-  console.log('http server listening on port', settings.port);
+  console.log('http' + (settings.https ? 's' : '') + ' server listening on port', settings.port);
 });

--- a/server.js
+++ b/server.js
@@ -1,17 +1,23 @@
 'use strict';
 
 var http = require('http');
+var https = require('https');
 var SonosDiscovery = require('sonos-discovery');
 var SonosHttpAPI = require('./lib/sonos-http-api.js');
 var nodeStatic = require('node-static');
 var fs = require('fs');
 var path = require('path');
 var webroot = path.resolve(__dirname, 'static');
+var auth = require('basic-auth');
 
 var settings = {
   port: 5005,
   cacheDir: './cache',
-  webroot: webroot
+  webroot: webroot,
+  ssl: false,
+  auth: false,
+  name: 'user',
+  pass: 'pass'
 };
 
 // Create webroot + tts if not exist
@@ -35,11 +41,37 @@ if (userSettings) {
   }
 }
 
+var options = {}
+
+if (settings.ssl) {
+  console.log('using SSL');
+  options = {
+    key: fs.readFileSync(path.resolve(__dirname, 'key.pem')),
+    cert: fs.readFileSync(path.resolve(__dirname, 'cert.pem'))
+  };
+}
+
+if (settings.auth) {
+  console.log('requires authorization');
+}
+
 var fileServer = new nodeStatic.Server(webroot);
 var discovery = new SonosDiscovery(settings);
 var api = new SonosHttpAPI(discovery, settings);
 
-var server = http.createServer(function (req, res) {
+var requestListener = function (req, res) {
+	
+  if (settings.auth) {	
+    var credentials = auth(req)
+ 
+    if (!credentials || credentials.name !== settings.name || credentials.pass !== settings.pass) {
+      res.statusCode = 401
+      res.setHeader('WWW-Authenticate', 'Basic realm="example"')
+      res.end('Access denied')
+      return
+    }
+  }
+
   req.addListener('end', function () {
     fileServer.serve(req, res, function (err) {
       // If error, route it.
@@ -52,7 +84,9 @@ var server = http.createServer(function (req, res) {
       }
     });
   }).resume();
-});
+}
+
+var server = (settings.ssl ? https.createServer(options, requestListener) : http.createServer(requestListener));
 
 server.listen(settings.port, function () {
   console.log('http server listening on port', settings.port);

--- a/server.js
+++ b/server.js
@@ -44,15 +44,10 @@ if (userSettings) {
 var options = {}
 
 if (settings.https) {
-  console.log('using https');
   options = {
     key: fs.readFileSync(path.resolve(__dirname, 'key.pem')),
     cert: fs.readFileSync(path.resolve(__dirname, 'cert.pem'))
   };
-}
-
-if (settings.auth) {
-  console.log('requires authorization');
 }
 
 var fileServer = new nodeStatic.Server(webroot);
@@ -89,5 +84,7 @@ var requestListener = function (req, res) {
 var server = (settings.https ? https.createServer(options, requestListener) : http.createServer(requestListener));
 
 server.listen(settings.port, function () {
-  console.log('http' + (settings.https ? 's' : '') + ' server listening on port', settings.port);
+  console.log((settings.https ? 'https' : 'http'),
+    'server listening on port', settings.port,
+    (settings.auth ? 'with authorization required' : ''));
 });

--- a/server.js
+++ b/server.js
@@ -14,7 +14,7 @@ var settings = {
   port: 5005,
   cacheDir: './cache',
   webroot: webroot,
-  ssl: false,
+  https: false,
   auth: false,
   name: 'user',
   pass: 'pass'
@@ -43,8 +43,8 @@ if (userSettings) {
 
 var options = {}
 
-if (settings.ssl) {
-  console.log('using SSL');
+if (settings.https) {
+  console.log('using https');
   options = {
     key: fs.readFileSync(path.resolve(__dirname, 'key.pem')),
     cert: fs.readFileSync(path.resolve(__dirname, 'cert.pem'))
@@ -86,7 +86,7 @@ var requestListener = function (req, res) {
   }).resume();
 }
 
-var server = (settings.ssl ? https.createServer(options, requestListener) : http.createServer(requestListener));
+var server = (settings.https ? https.createServer(options, requestListener) : http.createServer(requestListener));
 
 server.listen(settings.port, function () {
   console.log('http server listening on port', settings.port);


### PR DESCRIPTION
Added the ability to enable https connections and http basic authorization to make this safer to use from the Internet.  These can be specified via 'https', 'auth', 'name', and 'pass' in settings.json.