### PR TITLE
Added support for Spotify playlists and albums

### DIFF
--- a/lib/actions/spotify.js
+++ b/lib/actions/spotify.js
@@ -5,12 +5,19 @@ var metadataTemplate = '<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" x
 
 function spotify(player, values) {
   var action = values[0];
-  var encodedSpotifyUri = encodeURIComponent(values[1]);
+  var spotifyUri = values[1];
+  var encodedSpotifyUri = encodeURIComponent(spotifyUri);
 
-  var uri = 'x-sonos-spotify:' + encodedSpotifyUri + '?sid=9&flags=32&sn=1';
+  //check if current uri is either a track or a playlist/album
+  if(spotifyUri.startsWith('spotify:track:'))
+  {
+	var uri = 'x-sonos-spotify:' + encodedSpotifyUri + '?sid=9&flags=32&sn=1';
+  }else{
+	var uri = 'x-rincon-cpcontainer:0006206c' + encodedSpotifyUri;
+  }
 
   var metadata = metadataTemplate.format({uri: encodedSpotifyUri});
-
+  
   if (action == 'queue') {
     player.coordinator.addURIToQueue(uri, metadata);
   } else if(action == 'now') {


### PR DESCRIPTION
Added some logic for playlist and album handling.
Works with public and private playlists and the existing syntax (now, next, queue):
http://localhost:5005/roomname/spotify/next/spotify:user:00000:playlist:0000
http://localhost:5005/roomname/spotify/queue/spotify:album:6TbkWAqqY4nhQnYim61IU8
