### PR TITLE
Added playlists request module

### DIFF
--- a/lib/actions/playlists.js
+++ b/lib/actions/playlists.js
@@ -1,0 +1,22 @@
+function playlists(player, values, callback) {
+
+  callback.invokeIntended = true;
+  player.getPlaylists(function (error, playlists) {
+
+    if (values[0] === 'detailed') {
+      callback(playlists);
+      return;
+    }
+
+    // only present relevant data
+    var simplePlaylists = [];
+    playlists.forEach(function (i) {
+      simplePlaylists.push(i.title);
+    });
+    callback(simplePlaylists);
+  });
+}
+
+module.exports = function (api) {
+  api.registerAction('playlists', playlists);
+}


### PR DESCRIPTION
Added the playlists.js file which operates in the same way as favorites.js but returns available playlists instead.

Required for https://github.com/jishi/node-sonos-discovery/pull/59 

You can visit http://localhost:5005/playlists to pull a JSON list of available playlists