### PR TITLE
Fix for uri showing as title in Sonos controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,8 +371,10 @@ The supported language codes are:
 |es-es|Spanish (Spain)|
 |sv-se|Swedish (Sweden)|
 
-Spotify, Apple Music, and SiriusXM (Experimental)
+Spotify and Apple Music (Experimental)
 ----------------------
+
+Allows you to perform your own external searches for Apple Music or Spotify songs or albums and play a specified song or track ID. The Music Search funtionality outlined further below performs a search of its own and plays the specified music. 
 
 The following endpoints are available:
 
@@ -385,9 +387,6 @@ The following endpoints are available:
 # Apple Music
 /RoomName/applemusic/{now,next,queue}/song:{songID}
 /RoomName/applemusic/{now,next,queue}/album:{albumID}
-
-# SiriusXM
-/RoomName/siriusXM/{channel number,station name}
 ```
 
 You can find Apple Music song and album IDs via the [iTunes Search
@@ -395,7 +394,36 @@ API](https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web
 
 It only handles a single spotify account currently. It will probably use the first account added on your system. 
 
+
+SiriusXM
+----------------------
 You can specify a SiriusXM channel number or station name and the station will be played.
+
+```
+/RoomName/siriusXM/{channel number,station name}
+```
+
+
+Pandora
+----------------------
+Perform a search for one of your Pandora stations and begin playing. Give the currently playing song a thumbs up or thumbs down. Requires a valid Pandora account and credentials. 
+
+The following endpoints are available:
+
+```
+/RoomName/pandora/play/{station name}     Plays the closest match to the specified station name in your list of Pandora stations
+/RoomName/pandora/thumbsup                Gives the current playing Pandora song a thumbs up
+/RoomName/pandora/thumbsdown              Gives the current playing Pandora song a thumbs down 
+```
+
+Your Pandora credentials need to be added to the settings.json file
+   ```
+      ,
+      "pandora": {
+        "username": "YOUR PANDORA ACCOUNT EMAIL ADDRESS",
+        "password": "YOUR PANDORA PASSWORD"
+      }
+```
 
 
 Music Search and Play

--- a/README.md
+++ b/README.md
@@ -284,10 +284,10 @@ Example:
 	    "password": "password"
 	  },
 	  "announceVolume": 40,
-          "pandora": {
-            "username": "your-pandora-account-email-address",
-            "password": "your-pandora-password"
-          }
+	  "pandora": {
+	    "username": "your-pandora-account-email-address",
+	    "password": "your-pandora-password"
+	  }
 	}
 ```
 

--- a/README.md
+++ b/README.md
@@ -426,8 +426,9 @@ Your Pandora credentials need to be added to the settings.json file
           "pandora": {
             "username": "your-pandora-account-email-address",
             "password": "your-pandora-password"
-          }```
-
+          }
+  ```
+ 
 
 Music Search and Play
 ----------------------

--- a/README.md
+++ b/README.md
@@ -283,7 +283,11 @@ Example:
 	    "username": "admin",
 	    "password": "password"
 	  },
-	  "announceVolume": 40
+	  "announceVolume": 40,
+          "pandora": {
+            "username": "your-pandora-account-email-address",
+            "password": "your-pandora-password"
+          }
 	}
 ```
 
@@ -418,12 +422,11 @@ The following endpoints are available:
 
 Your Pandora credentials need to be added to the settings.json file
    ```
-      ,
-      "pandora": {
-        "username": "YOUR PANDORA ACCOUNT EMAIL ADDRESS",
-        "password": "YOUR PANDORA PASSWORD"
-      }
-```
+          ,
+          "pandora": {
+            "username": "your-pandora-account-email-address",
+            "password": "your-pandora-password"
+          }```
 
 
 Music Search and Play

--- a/lib/actions/pandora.js
+++ b/lib/actions/pandora.js
@@ -1,0 +1,107 @@
+const settings = require('../../settings.json');
+const promise = require('request-promise');
+const Anesidora = require("anesidora");
+const Fuse = require('fuse.js');
+
+function getPandoraMetadata(id, title, auth) {
+  return `<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"
+        xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+        <item id="OOOX${id}" parentID="0" restricted="true"><dc:title>${title}</dc:title><upnp:class>object.item.audioItem.audioBroadcast</upnp:class>
+        <desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON3_${auth}</desc></item></DIDL-Lite>`;
+}
+
+function getPandoraUri(id, title, albumart) {
+  return `pndrradio:${id}?sn=2,"title":"${title}","albumArtUri":"${albumart}"`;
+  return `x-sonos-http:${id}.mp4?sid=204&flags=8224&sn=4`;
+
+}
+
+
+function pandora(player, values) {
+  const cmd = values[0];
+
+
+  function playPandora(player, name) {
+    return new Promise(function(resolve, reject) {
+    
+        pAPI.login(function(err) {
+           if (!err) {
+             pAPI.request("user.getStationList", {"includeStationArtUrl" : true}, function(err, stationList) {
+               if (!err) {
+                 var fuzzy = new Fuse(stationList.stations, { keys: ["stationName"] });
+                 results = fuzzy.search(name);
+                 if (results.length > 0) {
+                   station = results[0];
+                   const uri = getPandoraUri(station.stationId, station.stationName, station.artUrl);
+                   const metadata = getPandoraMetadata(station.stationId, station.stationName, 'the.plourdes@gmail.com');
+        
+                   return player.coordinator.setAVTransport(uri, metadata) 
+                     .then(() => player.coordinator.play())
+                     .then(() => resolve('success'));
+                 } else {
+                   reject('No match found for ' + name);
+                 } 
+               }
+             });
+           }
+        });
+    }, Promise.resolve('success')); 
+  }
+
+  function thumbsPandora(sid, tid, up) {
+    return new Promise(function(resolve, reject) {
+
+        pAPI.login(function(err) {
+           if (!err) {
+             const req = {"stationToken" : sid, 
+                          "trackToken" : tid, 
+                          "isPositive" : up};
+             console.log(req);             
+         
+             pAPI.request("station.addFeedback", req, function(err, result) {
+               if (!err) {
+                 resolve('success');
+               } else {
+                 reject('There was a problem recording your thumbs ' + ((up)?'up':'down'));
+               }
+             });
+           }
+        });
+    }, Promise.resolve('success'));  
+  }
+
+
+  if (settings && settings.pandora) {
+    var pAPI = new Anesidora(settings.pandora.username, settings.pandora.password);
+
+    if (cmd == 'play') {
+      return playPandora(player, values[1]);
+    } if ((cmd == 'thumbsup')||(cmd == 'thumbsdown')) {
+      const uri = player.state.currentTrack.uri;
+   
+      if (uri.startsWith('pndrradio-http')) {
+        const stationToken = uri.substring(uri.search('&x=') + 3);
+        const trackToken = uri.substring(uri.search('&m=') + 3,uri.search('&f='));
+
+        return thumbsPandora(stationToken, trackToken, (cmd == 'thumbsup'))
+          .then(() => {
+            if (cmd == 'thumbsdown') {
+              return player.coordinator.nextTrack();
+            } 
+          });
+      } else {
+        return Promise.reject('The music that is playing is not a Pandora station');
+      }
+    }
+  } else {
+    console.log('Missing Pandora settings');
+    return Promise.reject('Missing Pandora settings');
+  }
+  
+}
+
+
+module.exports = function (api) {
+  api.registerAction('pandora', pandora);
+}
+

--- a/lib/music_services/appleDef.js
+++ b/lib/music_services/appleDef.js
@@ -84,6 +84,10 @@ function getMetadata(type, id, name, title) {
   const parentUri = appleDef.parent[type] + name;
   const objectType = appleDef.object[type];
   
+  if (type != 'station') {
+    title = '';
+  }
+
   return `<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"
           xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
           <item id="${id}" parentID="${parentUri}" restricted="true"><dc:title>${title}</dc:title><upnp:class>object.${objectType}</upnp:class>

--- a/lib/music_services/deezerDef.js
+++ b/lib/music_services/deezerDef.js
@@ -84,6 +84,10 @@ function getMetadata(type, id, name, title) {
   const parentUri = deezerDef.parent[type] + name;
   const objectType = deezerDef.object[type];
   
+  if (type != 'station') {
+    title = '';
+  }
+
   return `<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"
           xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
           <item id="${id}" parentID="${parentUri}" restricted="true"><dc:title>${title}</dc:title><upnp:class>object.${objectType}</upnp:class>

--- a/lib/music_services/libraryDef.js
+++ b/lib/music_services/libraryDef.js
@@ -67,6 +67,10 @@ function getMetadata(type, id, name, title) {
   const parentUri = libraryDef.parent[type] + name;
   const objectType = libraryDef.object[type];
   
+  if (type != 'station') {
+    title = '';
+  }
+
   return `<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"
           xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
           <item id="${id}" parentID="${parentUri}" restricted="true"><dc:title>${title}</dc:title><upnp:class>object.${objectType}</upnp:class>

--- a/lib/music_services/spotifyDef.js
+++ b/lib/music_services/spotifyDef.js
@@ -83,6 +83,10 @@ function getMetadata(type, id, name, title) {
   const parentUri = spotifyDef.parent[type] + name;
   const objectType = spotifyDef.object[type];
   
+  if (type != 'station') {
+    title = '';
+  }
+
   return `<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"
           xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
           <item id="${id}" parentID="${parentUri}" restricted="true"><dc:title>${title}</dc:title><upnp:class>object.${objectType}</upnp:class>


### PR DESCRIPTION
Some special characters in a title causes the Sonos controller to display the uri as the title.  This fix blanks out the title for anything that is not a station type, where we do want a "Radio" title.
