### PR TITLE
Removed need for mcrypt

### DIFF
--- a/lib/actions/pandora.js
+++ b/lib/actions/pandora.js
@@ -37,7 +37,7 @@ function pandora(player, values) {
         
                    return player.coordinator.setAVTransport(uri, metadata) 
                      .then(() => player.coordinator.play())
-                     .then(() => resolve('success'));
+                     .then(() => resolve());
                  } else {
                    reject('No match found for ' + name);
                  } 
@@ -45,7 +45,7 @@ function pandora(player, values) {
              });
            }
         });
-    }, Promise.resolve('success')); 
+    }, Promise.resolve()); 
   }
 
   function thumbsPandora(sid, tid, up) {
@@ -60,14 +60,14 @@ function pandora(player, values) {
          
              pAPI.request("station.addFeedback", req, function(err, result) {
                if (!err) {
-                 resolve('success');
+                 resolve();
                } else {
                  reject('There was a problem recording your thumbs ' + ((up)?'up':'down'));
                }
              });
            }
         });
-    }, Promise.resolve('success'));  
+    }, Promise.resolve());  
   }
 
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "basic-auth": "~1.0.3",
     "fuse.js": "^2.2.0",
+    "mcrypt": "^0.1.7",
     "anesidora": "https://github.com/dlom/anesidora",
     "node-static": "~0.7.0",
     "request-promise": "~1.0.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "basic-auth": "~1.0.3",
     "fuse.js": "^2.2.0",
-    "anesidora": "https://github.com/jplourde5/anesidora",
+    "anesidora": "https://github.com/dlom/anesidora",
     "node-static": "~0.7.0",
     "request-promise": "~1.0.2",
     "sonos-discovery": "https://github.com/jishi/node-sonos-discovery/archive/v1.0.0-beta.21.tar.gz"

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   "dependencies": {
     "basic-auth": "~1.0.3",
     "fuse.js": "^2.2.0",
-    "mcrypt": "^0.1.7",
-    "anesidora": "https://github.com/dlom/anesidora",
+    "anesidora": "https://github.com/jplourde5/anesidora",
     "node-static": "~0.7.0",
     "request-promise": "~1.0.2",
     "sonos-discovery": "https://github.com/jishi/node-sonos-discovery/archive/v1.0.0-beta.21.tar.gz"


### PR DESCRIPTION
Forked the Anesidora project and replaced mcrypt with standard node.js crypto.  You may want to setup your own fork like I think you did with fuse. 