### PR TITLE
Update pandora.js

### DIFF
--- a/lib/actions/pandora.js
+++ b/lib/actions/pandora.js
@@ -17,71 +17,99 @@ function getPandoraMetadata(id, title, auth) {
 }
 
 function getPandoraUri(id, title, albumart) {
-  return `pndrradio:${id}?sn=2,"title":"${title}","albumArtUri":"${albumart}"`;
-  return `x-sonos-http:${id}.mp4?sid=204&flags=8224&sn=4`;
-
+  if (albumart == undefined) {
+    return `pndrradio:${id}?sn=2`;
+  } else {
+    return `pndrradio:${id}?sn=2,"title":"${title}","albumArtUri":"${albumart}"`;
+  }  
 }
 
 
 function pandora(player, values) {
   const cmd = values[0];
 
-
-  function playPandora(player, name) {
+  function userLogin() {
     return new Promise(function(resolve, reject) {
-    
-        pAPI.login(function(err) {
-           if (!err) {
-             pAPI.request("user.getStationList", {"includeStationArtUrl" : true}, function(err, stationList) {
-               if (!err) {
-                 var fuzzy = new Fuse(stationList.stations, { keys: ["stationName"] });
-                 results = fuzzy.search(name);
-                 if (results.length > 0) {
-                   station = results[0];
-                   const uri = getPandoraUri(station.stationId, station.stationName, station.artUrl);
-                   const metadata = getPandoraMetadata(station.stationId, station.stationName, 'the.plourdes@gmail.com');
-        
-                   return player.coordinator.setAVTransport(uri, metadata) 
-                     .then(() => player.coordinator.play())
-                     .then(() => resolve());
-                 } else {
-                   reject('No match found for ' + name);
-                 } 
-               }
-             });
-           } else {
-             console.log(err);
-             reject('Error logging into the Pandora API');
-           }
-        });
+      pAPI.login(function(err) {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
     });
   }
 
-  function thumbsPandora(sid, tid, up) {
+  function pandoraAPI(command, parameters) {
     return new Promise(function(resolve, reject) {
-
-        pAPI.login(function(err) {
-           if (!err) {
-             const req = {"stationToken" : sid, 
-                          "trackToken" : tid, 
-                          "isPositive" : up};
-             console.log(req);             
-         
-             pAPI.request("station.addFeedback", req, function(err, result) {
-               if (!err) {
-                 resolve();
-               } else {
-                 reject('There was a problem recording your thumbs ' + ((up)?'up':'down'));
-               }
-             });
-           } else {
-             console.log(err);
-             reject('Error logging into the Pandora API');
-           }
-        });
-    });  
+      pAPI.request(command, parameters, function(err, result) {
+        if (!err) {
+          resolve(result);
+        } else {
+          console.log("pandoraAPI " + command + " " + JSON.stringify(parameters));
+          console.log("ERROR: " + JSON.stringify(err));
+          reject(err);
+        }
+      });
+    });
   }
 
+  function playPandora(player, name) {
+    var uri = '';
+    var metadata = '';
+
+    return userLogin()
+      .then(() => pandoraAPI("user.getStationList", {"includeStationArtUrl" : true}))
+      .then((stationList) => {
+        return pandoraAPI("music.search", {"searchText": name})
+          .then((result) => {
+            if (result.artists != undefined) {          
+              result.artists.map(function(artist) {
+                if (artist.score > 90) {
+                  stationList.stations.push({"stationId":artist.musicToken,"stationName":artist.artistName,"type":"artist"});
+                }
+              });
+            }
+            if (result.songs != undefined) {          
+              result.songs.map(function(song) { 
+                if (song.score > 90) {
+                  stationList.stations.push({"stationId":song.musicToken,"stationName":song.songName,"type":"song"});
+                }
+              });
+            }
+            return pandoraAPI("station.getGenreStations", {});
+          })
+          .then((result) => { 
+            result.categories.map(function(category) {
+              category.stations.map(function(genreStation) {
+                stationList.stations.push({"stationId":genreStation.stationToken,"stationName":genreStation.stationName,"type":"song"});
+              });
+            });
+            var fuzzy = new Fuse(stationList.stations, { keys: ["stationName"] });
+                 
+            results = fuzzy.search(name);
+            if (results.length > 0) {
+              station = results[0];
+              if (station.type == undefined) {
+                uri = getPandoraUri(station.stationId, station.stationName, station.artUrl);
+                metadata = getPandoraMetadata(station.stationId, station.stationName, settings.pandora.username);
+                return Promise.resolve();
+              } else {
+                return pandoraAPI("station.createStation", {"musicToken":station.stationId, "musicType":station.type})
+                  .then((stationInfo) => {
+                  	 uri = getPandoraUri(stationInfo.stationId);
+                     metadata = getPandoraMetadata(stationInfo.stationId, stationInfo.stationName, settings.pandora.username);
+                     return Promise.resolve();
+                  });
+              }
+            } else {
+              return Promise.reject("No match was found");
+            }  
+          }) 
+          .then(() => player.coordinator.setAVTransport(uri, metadata))
+          .then(() => player.coordinator.play());
+      });  
+  }
 
   if (settings && settings.pandora) {
     var pAPI = new Anesidora(settings.pandora.username, settings.pandora.password);
@@ -94,8 +122,9 @@ function pandora(player, values) {
       if (uri.startsWith('pndrradio-http')) {
         const stationToken = uri.substring(uri.search('&x=') + 3);
         const trackToken = uri.substring(uri.search('&m=') + 3,uri.search('&f='));
+        const up = (cmd == 'thumbsup');
 
-        return thumbsPandora(stationToken, trackToken, (cmd == 'thumbsup'))
+        return pandoraAPI("station.addFeedback", {"stationToken" : stationToken, "trackToken" : trackToken, "isPositive" : up})
           .then(() => {
             if (cmd == 'thumbsdown') {
               return player.coordinator.nextTrack();
@@ -109,7 +138,6 @@ function pandora(player, values) {
     console.log('Missing Pandora settings');
     return Promise.reject('Missing Pandora settings');
   }
-  
 }
 
 


### PR DESCRIPTION
Enhanced to support:

1. Playing Genre Stations in addition to user stations
2. Will create a new station on the fly for specified songs or artists if the specified name is not found.

There is no change to the API interface.  The routine will simply search user stations and genre stations for the specified name, and will create a new station for the specified name if needed.