### PR TITLE
Spike at adding static file support to the say/sayall commands.

### DIFF
--- a/lib/actions/say_v2.js
+++ b/lib/actions/say_v2.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const http = require('http');
 const isRadioOrLineIn = require('../helpers/is-radio-or-line-in');
 const tryDownloadTTS = require('../helpers/try-download-tts');
+const tryStaticTTS = require('../helpers/try-static-tts');
 
 let port;
 let system;
@@ -134,7 +135,16 @@ function say(player, values) {
     return system.applyPreset(relevantBackupPreset);
   }
 
-  return tryDownloadTTS(text, language)
+  let fileURI;
+
+  if text.startsWith("static_tts_") {
+    fileURI = tryLocalTTS(text);
+  }
+  else {
+    fileURI = tryDownloadTTS(text, language);
+  }
+
+  return fileURI
     .then((uri) => {
       ttsPreset.uri = `http://${system.localEndpoint}:${port}${uri}`;
       return system.applyPreset(ttsPreset);

--- a/lib/actions/sayall.js
+++ b/lib/actions/sayall.js
@@ -2,6 +2,7 @@
 const path = require('path');
 const isRadioOrLineIn = require('../helpers/is-radio-or-line-in');
 const tryDownloadTTS = require('../helpers/try-download-tts');
+const tryStaticTTS = require('../helpers/try-static-tts');
 let port;
 let system;
 
@@ -121,7 +122,16 @@ function sayAll(player, values) {
     }
   };
 
-  return tryDownloadTTS(text, language)
+  let fileURI;
+
+  if text.startsWith("static_tts_") {
+    fileURI = tryLocalTTS(text);
+  }
+  else {
+    fileURI = tryDownloadTTS(text, language);
+  }
+
+  return fileURI
     .then(uri => {
       preset.uri = `http://${system.localEndpoint}:${port}${uri}`;
       return system.applyPreset(preset);

--- a/lib/helpers/try-static-tts.js
+++ b/lib/helpers/try-static-tts.js
@@ -1,0 +1,33 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const webroot = path.resolve(__dirname + '/../../static');
+
+let settings = {};
+try {
+  settings = require.main.require('./settings.json');
+} catch (e) {
+  console.error(e);
+}
+
+function tryStaticTTS(phrase) {
+  if (!phrase.startWith("static_tts_")) {
+    reject(new Error('All local TTS requests must begin with "tts_".'));
+  }
+
+  phrase = phrase.replace(/^static_tts_/,'');
+
+  const filename = settings.staticTTS.phrases[phrase];
+  const filepath = path.resolve(webroot, 'static_tts', filename);
+
+  const expectedUri = `/static_tts/${filename}`;
+  try {
+    fs.accessSync(filepath, fs.R_OK);
+    return Promise.resolve(expectedUri);
+  } catch (err) {
+    reject(new Error(`static file for phrase "${phrase}" does not seem to exist.`));
+  }
+}
+
+module.exports = tryStaticTTS;

--- a/server.js
+++ b/server.js
@@ -14,6 +14,10 @@ var settings = {
   port: 5005,
   securePort: 5006,
   cacheDir: './cache',
+  staticTTS: {
+    phrases: {
+    }
+  }
   webroot: webroot,
   announceVolume: 40
 };


### PR DESCRIPTION
:warning: Proof of concept :warning: 

I am wanting to use `node-sonos-http-api` for a TTS related use case, but I'd prefer not to have the runtime reliance on an external service for the TTS. So, I'd like to propose some means of having the API play back prerecorded files. I guess this could be used outside of TTS, though my primary use case is that. For example, I'd like to have a set of prerecorded things like:

* The backdoor was opened.
* Motion was detected in the basement.
* ...

Before I spent any real time on it, I thought I'd open up a quick spike to get your feedback on whether it is a feature you would consider merging in. And, if so, your thoughts on the way you would like to see it integrated. For example, since playing backs static files could be used for things besides TTS, would you like to see a new API endpoint? Or, are you a proponent of putting it inside the existing `say`/`sayAll` APIs? 