### PR TITLE
Update libraryDef.js

### DIFF
--- a/lib/music_services/libraryDef.js
+++ b/lib/music_services/libraryDef.js
@@ -255,10 +255,19 @@ function loadLibrarySearch(player, load) {
   }
 }
 
+Array.prototype.shuffle=function(){
+  var len = this.length,temp,i
+  while(len){
+    i=Math.random()*len-- >>> 0;
+    temp=this[len],this[len]=this[i],this[i]=temp;
+  }
+  return this;
+}
+
 function searchLibrary(type, term) {
   term = decodeURIComponent(term);
 
-  return (type == 'album') ? fuzzyAlbums.search(term) : fuzzyTracks.search(term).slice(0,maxlibtracks);
+  return (type == 'album') ? fuzzyAlbums.search(term) : fuzzyTracks.search(term).shuffle().slice(0,maxlibtracks);
 }
 
 function isEmpty(type, resList) {

--- a/lib/music_services/libraryDef.js
+++ b/lib/music_services/libraryDef.js
@@ -4,6 +4,14 @@ const fs = require("fs");
 
 const libraryPath = "./lib/library.json";
 
+let settings = {};
+
+try {
+  settings = require('../../settings.json');
+} catch (e) {}
+
+var maxlibtracks = (settings.maxlibtracks != undefined)?settings.maxlibtracks:50;
+
 var musicLibrary = null;
 var fuzzyTracks = null;
 var fuzzyAlbums = null;
@@ -250,7 +258,7 @@ function loadLibrarySearch(player, load) {
 function searchLibrary(type, term) {
   term = decodeURIComponent(term);
 
-  return (type == 'album') ? fuzzyAlbums.search(term) : fuzzyTracks.search(term);
+  return (type == 'album') ? fuzzyAlbums.search(term) : fuzzyTracks.search(term).slice(0,maxlibtracks);
 }
 
 function isEmpty(type, resList) {

--- a/lib/music_services/libraryDef.js
+++ b/lib/music_services/libraryDef.js
@@ -10,7 +10,7 @@ try {
   settings = require('../../settings.json');
 } catch (e) {}
 
-var maxlibtracks = (settings.maxlibtracks != undefined)?settings.maxlibtracks:50;
+var randomQueueLimit = (settings.library.randomQueueLimit != undefined)?settings.library.randomQueueLimit:50;
 
 var musicLibrary = null;
 var fuzzyTracks = null;
@@ -267,7 +267,7 @@ Array.prototype.shuffle=function(){
 function searchLibrary(type, term) {
   term = decodeURIComponent(term);
 
-  return (type == 'album') ? fuzzyAlbums.search(term) : fuzzyTracks.search(term).shuffle().slice(0,maxlibtracks);
+  return (type == 'album') ? fuzzyAlbums.search(term) : fuzzyTracks.search(term).shuffle().slice(0,randomQueueLimit);
 }
 
 function isEmpty(type, resList) {


### PR DESCRIPTION
Limits the track count to 50 by default.  Can be set to a higher number by including a "maxlibtracks": VALUE in settings.