### PR TITLE
Fixes Problem With Duplicate Album Names

### DIFF
--- a/lib/actions/musicSearch.js
+++ b/lib/actions/musicSearch.js
@@ -137,6 +137,9 @@ function loadTracks(service, type, tracksJson)
 {
   var tracks = getService(service).tracks(type, tracksJson);
   
+  if ((service == 'library') && (type == 'album')) {
+    tracks.isArtist = true;
+  } else 
   if (type != 'album') {
     if (searchType == 0) {
       // Determine if the request was for a specific song or for many songs by a specific artist
@@ -214,7 +217,7 @@ function musicSearch(player, values) {
           return player.coordinator.setAVTransport(UaM.uri, UaM.metadata) 
             .then(() => player.coordinator.play());
         } else 
-        if (type == 'album') {
+        if ((type == 'album') && (service != 'library')) {
           UaM = serviceDef.urimeta(type, resList);
 
           return player.coordinator.clearQueue()

--- a/lib/music_services/libraryDef.js
+++ b/lib/music_services/libraryDef.js
@@ -8,7 +8,7 @@ const libraryPath = path.join(settings.cacheDir, 'library.json');
 var randomQueueLimit = (settings.library && settings.library.randomQueueLimit !== undefined)?settings.library.randomQueueLimit:50;
 
 var musicLibrary = null;
-var currentLibVersion = 1.3;
+var currentLibVersion = 1.4;
 var fuzzyTracks = null;
 var fuzzyAlbums = null;
 
@@ -108,7 +108,7 @@ function loadTracks(type, tracksJson) {
           tracksArray.push({
             trackName: track.trackName,
             artistName: track.artistName,
-            trackNum:track.trackNum, 
+            albumTrackNumber:track.albumTrackNumber, 
             uri: track.uri,
             metadata: track.metadata
           });
@@ -124,7 +124,7 @@ function loadTracks(type, tracksJson) {
       if (a.artistName != b.artistName) {
         return (a.artistName > b.artistName)? 1 : -1;
       } else {
-        return a.trackNum - b.trackNum;
+        return a.albumTrackNumber - b.albumTrackNumber;
       }
     });
   }
@@ -177,7 +177,7 @@ function loadLibrary(player) {
           trackName: item.title,
           artistName: item.artist,
           albumName: item.album,
-          trackNum: item.tracknum,
+          albumTrackNumber: item.albumTrackNumber,
           uri: item.uri,
           metadata: metadata
         });

--- a/lib/music_services/libraryDef.js
+++ b/lib/music_services/libraryDef.js
@@ -8,7 +8,7 @@ const libraryPath = path.join(settings.cacheDir, 'library.json');
 var randomQueueLimit = (settings.library && settings.library.randomQueueLimit !== undefined)?settings.library.randomQueueLimit:50;
 
 var musicLibrary = null;
-var currentLibVersion = 1.2;
+var currentLibVersion = 1.3;
 var fuzzyTracks = null;
 var fuzzyAlbums = null;
 
@@ -23,17 +23,17 @@ const libraryDef = {
     station: ''
   },
   metastart: {
-    album: 'A:ALBUM/',
+    album: 'S:',
     song: 'S:',
     station: ''
   },
   parent: {
-    album: 'A:ALBUM',
+    album: 'A:ALBUMARTIST/',
     song: 'A:ALBUMARTIST/',
     station: ''
   },
   object: {
-    album: 'container.album.musicAlbum',
+    album: 'item.audioItem.musicTrack',
     song: 'item.audioItem.musicTrack',
     station: ''
   },
@@ -89,37 +89,44 @@ function loadTracks(type, tracksJson) {
   };
 
   if (tracksJson.length > 0) {
-    if (type == 'album') {
-      tracks.queueTracks.push({
-        albumName: tracksJson[0].albumName,
-        uri: tracksJson[0].uri,
-        metadata: tracksJson[0].metadata
-      });
-      tracks.count = 1;
-    } else {
+    var albumName = tracksJson[0].albumName;
 
-      // Filtered list of tracks to play
-      tracks.queueTracks = tracksJson.reduce(function (tracksArray, track) {
-        if (tracks.count < 50) {
-          var skip = false;
+    // Filtered list of tracks to play
+    tracks.queueTracks = tracksJson.reduce(function(tracksArray, track) {
+      if (tracks.count < randomQueueLimit) {
+        var skip = false;
 
+        if (type == 'song') {
           for (var j = 0; (j < tracksArray.length) && !skip; j++) {
             // Skip duplicate songs
             skip = (track.trackName == tracksArray[j].trackName);
           }
-        }
+        } else {
+          skip = (track.albumName != albumName);
+        }          
         if (!skip) {
           tracksArray.push({
             trackName: track.trackName,
             artistName: track.artistName,
+            trackNum:track.trackNum, 
             uri: track.uri,
             metadata: track.metadata
           });
           tracks.count++;
         }
-        return tracksArray;
-      }, []);
-    }
+      }
+      return tracksArray;
+    }, []);
+  }
+  
+  if (type == 'album') {
+    tracks.queueTracks.sort(function(a,b) {
+      if (a.artistName != b.artistName) {
+        return (a.artistName > b.artistName)? 1 : -1;
+      } else {
+        return a.trackNum - b.trackNum;
+      }
+    });
   }
 
   return tracks;
@@ -147,17 +154,9 @@ function loadLibrary(player) {
   console.log("Loading Library");
   isLoading = true;
 
-  let loadingTracks = true;
-
   let library = {
     version: currentLibVersion,
     tracks: {
-      items: [],
-      startIndex: 0,
-      numberReturned: 0,
-      totalMatches: 1
-    },
-    albums: {
       items: [],
       startIndex: 0,
       numberReturned: 0,
@@ -169,60 +168,42 @@ function loadLibrary(player) {
 
   let getChunk = (chunk) => {
     chunk.items.reduce(function (tracksArray, item) {
-      if (loadingTracks) {
-        if ((item.uri != undefined) && (item.artist != undefined) && (item.album != undefined)) {
-          var metadataID = libraryDef.metastart['song'] + item.uri.substring(item.uri.indexOf(':') + 1);
-          var metadata = getMetadata('song', metadataID, encodeURIComponent(item.artist) + '/' + encodeURIComponent(item.album));
-          result.items.push({
-            artistTrackSearch: item.artist + ' ' + item.title,
-            trackName: item.title,
-            artistName: item.artist,
-            albumName: item.album,
-            uri: item.uri,
-            metadata: metadata
-          });
-        }
-      } else {
-        if ((item.uri != undefined) && (item.title != undefined)) {
-          var metadataID = libraryDef.metastart['album'] + encodeURIComponent(item.title);
-          var metadata = getMetadata('album', metadataID, '');
-          result.items.push({ 
-            artistAlbumSearch: item.artist + ' ' + item.title,
-          	albumName: item.title, 
-          	artistName: item.artist, 
-          	uri: item.uri, 
-          	metadata: metadata 
-          });
-        }
+      if ((item.uri != undefined) && (item.artist != undefined) && (item.album != undefined)) {
+        var metadataID = libraryDef.metastart['song'] + item.uri.substring(item.uri.indexOf(':') + 1);
+        var metadata = getMetadata('song', metadataID, encodeURIComponent(item.artist) + '/' + encodeURIComponent(item.album));
+        result.items.push({
+          artistTrackSearch: item.artist + ' ' + item.title,
+          artistAlbumSearch: item.artist + ' ' + item.album,
+          trackName: item.title,
+          artistName: item.artist,
+          albumName: item.album,
+          trackNum: item.tracknum,
+          uri: item.uri,
+          metadata: metadata
+        });
       }
     }, []);
 
     result.numberReturned += chunk.numberReturned;
     result.totalMatches = chunk.totalMatches;
-    console.log(((loadingTracks)?"Track ":"Album ") + "Count " + result.numberReturned);
+    console.log("Track Count " + result.numberReturned);
 
     if (isFinished(chunk)) {
-      if (loadingTracks) {
-        result = library.albums;
-        chunk = result;
-        loadingTracks = false;
-      } else {
-        return new Promise((resolve, reject) => {
-          fs.writeFile(libraryPath, JSON.stringify(library), (err) => {
-            isLoading = false;
-            if (err) {
-              console.log("ERROR: " + JSON.stringify(err));
-              return reject(err);
-            } else {
-              return resolve(library);
-            }
-          });
+      return new Promise((resolve, reject) => {
+        fs.writeFile(libraryPath, JSON.stringify(library), (err) => {
+          isLoading = false;
+          if (err) {
+            console.log("ERROR: " + JSON.stringify(err));
+            return reject(err);
+          } else {
+            return resolve(library);
+          }
         });
-      }
+      });
     }
 
     // Recursive promise chain
-    return player.browse((loadingTracks) ? 'A:TRACKS' : 'A:ALBUM', chunk.startIndex + chunk.numberReturned, 0)
+    return player.browse('A:TRACKS', chunk.startIndex + chunk.numberReturned, 0)
       .then(getChunk);
   }
 
@@ -240,7 +221,7 @@ function loadLibrarySearch(player, load) {
       .then((result) => {
         fuzzyTracks = result;
       })
-      .then(() => loadFuse(musicLibrary.albums.items, ["artistAlbumSearch", "albumName", "artistName"]))
+      .then(() => loadFuse(musicLibrary.tracks.items, ["artistAlbumSearch", "albumName", "artistName"]))
       .then((result) => {
         fuzzyAlbums = result;
         return Promise.resolve("Library and search loaded");
@@ -250,7 +231,7 @@ function loadLibrarySearch(player, load) {
       .then((result) => {
         fuzzyTracks = result;
       })
-      .then(() => loadFuse(musicLibrary.albums.items, ["artistAlbumSearch", "albumName", "artistName"]))
+      .then(() => loadFuse(musicLibrary.tracks.items, ["artistAlbumSearch", "albumName", "artistName"]))
       .then((result) => {
         fuzzyAlbums = result;
         return Promise.resolve("Library search loaded");


### PR DESCRIPTION
DEPENDENT ON sones-discovery ENHANCEMENT

Reverts back to building a library album using the library tracks instead of using an album search to avoid Sonos limitation around duplicate album names.  Fixes original album tack order problem by obtaining and sorting by the track number within an album