### PR TITLE
Making toggleMute toggle when player is grouped

### DIFF
--- a/lib/actions/mute.js
+++ b/lib/actions/mute.js
@@ -16,7 +16,7 @@ function groupUnmute(player) {
 }
 
 function toggleMute(player) {
-  if(player.coordinator.state.mute) {
+  if(player.state.mute) {
     return player.unMute();
   };
   


### PR DESCRIPTION
Is a player is grouped and not the coordinator, the previous implementation of toggleMute would mute the specified player correctly, but only unmute if the coordinator is also muted. Tested and works on my system.