### PR TITLE
Changed function invokeWebhook to allow for additional settings

### DIFF
--- a/lib/sonos-http-api.js
+++ b/lib/sonos-http-api.js
@@ -113,16 +113,16 @@ function HttpAPI(discovery, settings) {
   }
 
   function invokeWebhook(type, data) {
-    var type_name = "type";
-    var data_name = "data";
+    var typeName = "type";
+    var dataName = "data";
     if (!settings.webhook) return;
 
-    if (settings.webhook_type) { type_name = settings.webhook_type; }
-    if (settings.webhook_data) { data_name = settings.webhook_data; }
+    if (settings.webhookType) { typeName = settings.webhookType; }
+    if (settings.webhookData) { dataName = settings.webhookData; }
 
     const jsonBody = JSON.stringify({
-      [type_name]: type,
-      [data_name]: data
+      [typeName]: type,
+      [dataName]: data
     });
 
     const body = new Buffer(jsonBody, 'utf8');
@@ -131,8 +131,8 @@ function HttpAPI(discovery, settings) {
         'Content-Type': 'application/json',
         'Content-Length': body.length
       }
-    if (settings.webhook_header_name && settings.webhook_header_contents) {
-      headers[settings.webhook_header_name] = settings.webhook_header_contents;
+    if (settings.webhookHeaderName && settings.webhookHeaderContents) {
+      headers[settings.webhookHeaderName] = settings.webhookHeaderContents;
     }
 
     request({

--- a/lib/sonos-http-api.js
+++ b/lib/sonos-http-api.js
@@ -113,22 +113,32 @@ function HttpAPI(discovery, settings) {
   }
 
   function invokeWebhook(type, data) {
+    var type_name = "type";
+    var data_name = "data";
     if (!settings.webhook) return;
 
+    if (settings.webhook_type) { type_name = settings.webhook_type; }
+    if (settings.webhook_data) { data_name = settings.webhook_data; }
+
     const jsonBody = JSON.stringify({
-      type: type,
-      data: data
+      [type_name]: type,
+      [data_name]: data
     });
 
     const body = new Buffer(jsonBody, 'utf8');
 
+    var headers = {
+        'Content-Type': 'application/json',
+        'Content-Length': body.length
+      }
+    if (settings.webhook_header_name && settings.webhook_header_contents) {
+      headers[settings.webhook_header_name] = settings.webhook_header_contents;
+    }
+
     request({
       method: 'POST',
       uri: settings.webhook,
-      headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': body.length
-      },
+      headers: headers,
       body
     })
     .catch(function (err) {


### PR DESCRIPTION
The invokeWebhook function was changed so that the following settings can be used in the settings.json file:
webhook_type - set the name of the entity that contains the type (defaults to type)
webhook_data - set the name of the entity that contains the data (defaults to data)
webhook_header_name - add a header (for instance for authorization) (defaults to none)
webhook_header_contents - set the contents of the additional header.

The reason for this change is that I want to point this webhook to Splunk. Splunk requires an event entity in the payload in stead of a data entity and the type entity is unknown as well. In addition, authentication is done through the header "Authentication".

I have programmed it such that it is backwards compatible with the previous version.