### PR TITLE
Fix for empty status problem on a restarted Sonos

### DIFF
--- a/lib/helpers/is-radio-or-line-in.js
+++ b/lib/helpers/is-radio-or-line-in.js
@@ -8,7 +8,8 @@ function isRadioOrLineIn(uri) {
     uri.startsWith('x-rincon-stream:') ||
     uri.startsWith('x-sonos-htastream:') ||
     uri.startsWith('x-sonosprog-http:') ||
-    uri.startsWith('x-rincon-mp3radio:');
+    uri.startsWith('x-rincon-mp3radio:') ||
+    (uri == '');
 }
 
 module.exports = isRadioOrLineIn;


### PR DESCRIPTION
This is the cause of the strange problem that I was having earlier. Finally pinned it down to when a device has been restarted which blanks out the status. The uri is blank and the isRadioOrLineIn check returns as if the player is in queue mode. The error happens when the play command is issued but the queue mode is not on.