### PR TITLE
Added Spotify Authentication to MusicSearch

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,9 +344,10 @@ Example:
 
 Override as it suits you.
 
-Note for Spotify users!  To use Spotify:
+Note for Spotify users!
+-----------------------
 
-Go to https://developer.spotify.com/my-applications/#!/applications/create and create a Spotify application to get your client keys. You can name it Sonos or anything else and you don't have to change any values. Use the Client ID and the Client Secret values in the settings.json file as indicated above.
+To use Spotify, go to https://developer.spotify.com/my-applications/#!/applications/create and create a Spotify application to get your client keys. You can name it Sonos or anything else and you don't have to change any values. Use the Client ID and the Client Secret values in the settings.json file as indicated above.
 
 
 Favorites

--- a/README.md
+++ b/README.md
@@ -332,6 +332,10 @@ Example:
 	    "username": "your-pandora-account-email-address",
 	    "password": "your-pandora-password"
 	  },
+	  "spotify": {
+	    "clientId": "your-spotify-application-clientId",
+	    "clientSecret": "your-spotify-application-clientSecret"
+	  },
 	  "library": {
 	    "randomQueueLimit": 50
 	  }
@@ -340,6 +344,9 @@ Example:
 
 Override as it suits you.
 
+Note for Spotify users!  To use Spotify:
+
+Go to https://developer.spotify.com/my-applications/#!/applications/create and create a Spotify application to get your client keys. You can name it Sonos or anything else and you don't have to change any values. Use the Client ID and the Client Secret values in the settings.json file as indicated above.
 
 
 Favorites

--- a/lib/actions/musicSearch.js
+++ b/lib/actions/musicSearch.js
@@ -62,11 +62,20 @@ function getAccountId(player, service)
   }
 }
 
+function getRequestOptions(serviceDef, url) {
+  const headers = serviceDef.headers();
+  return {
+    url: url,
+    json: true,
+    headers: headers,
+  }
+};
 
 function doSearch(service, type, term)
 {
   var serviceDef = getService(service);
   var url = serviceDef.search[type];
+  var authenticate = serviceDef.authenticate;
 
   term = decodeURIComponent(term);
 
@@ -114,14 +123,14 @@ function doSearch(service, type, term)
            .then((res) => {
              country = res.country;
              url += serviceDef.country + country;
-             return request({url: url, json: true});
+             return authenticate().then(() => request(getRequestOptions(serviceDef, url)));
            });
   } else {
     if (serviceDef.country != '') {
       url += serviceDef.country + country;
     }
       
-    return request({url: url, json: true});
+    return authenticate().then(() => request(getRequestOptions(serviceDef, url)));
   }
 }
 
@@ -173,7 +182,11 @@ function loadTracks(service, type, tracksJson)
       tracks.isArtist = (searchType == 2);
     }
   }
-  
+ 
+  if (tracks.isArtist) {
+    tracks.queueTracks.shuffle();  
+  }
+ 
   return tracks;
 }
 
@@ -183,8 +196,7 @@ function musicSearch(player, values) {
   const type = values[1];
   const term = values[2];
   const queueURI = 'x-rincon-queue:' + player.uuid + '#0';
-  var   serviceDef = null;
-
+ 
   if (musicServices.indexOf(service) == -1) {
     return Promise.reject('Invalid music service');
   } 
@@ -199,11 +211,11 @@ function musicSearch(player, values) {
 
   return getAccountId(player, service)
     .then(() => {
-      serviceDef = getService(service);
-      serviceDef.service(player, accountId, accountSN, country);
       return doSearch(service, type, term);
     })
     .then((resList) => {
+      const serviceDef = getService(service);
+      serviceDef.service(player, accountId, accountSN, country);
       if (serviceDef.empty(type, resList)) {
         return Promise.reject('No matches were found');
       } else {

--- a/lib/actions/musicSearch.js
+++ b/lib/actions/musicSearch.js
@@ -143,7 +143,7 @@ Array.prototype.shuffle=function(){
   return this;
 }
 
-function loadTracks(service, type, tracksJson)
+function loadTracks(player, service, type, tracksJson)
 {
   var tracks = getService(service).tracks(type, tracksJson);
   
@@ -183,7 +183,8 @@ function loadTracks(service, type, tracksJson)
     }
   }
  
-  if (tracks.isArtist) {
+  //To avoid playing the same song first in a list of artist tracks when shuffle is on
+  if (tracks.isArtist && player.coordinator.state.playMode.shuffle) {
     tracks.queueTracks.shuffle();  
   }
  
@@ -235,7 +236,7 @@ function musicSearch(player, values) {
             .then(() => player.coordinator.addURIToQueue(UaM.uri, UaM.metadata, true, 1))
             .then(() => player.coordinator.play());
         } else { // Play songs
-          var tracks = loadTracks(service, type, resList);
+          var tracks = loadTracks(player, service, type, resList);
       
           if (tracks.count == 0) {
             return Promise.reject('No matches were found');

--- a/lib/music_services/appleDef.js
+++ b/lib/music_services/appleDef.js
@@ -28,11 +28,11 @@ const appleDef = {
   empty:     isEmpty,
   metadata:  getMetadata,
   urimeta:   getURIandMetadata,
-  headers:   getHeaders,
+  headers:   getTokenHeaders,
   authenticate: authenticateService
 }  
 
-function getHeaders() {
+function getTokenHeaders() {
   return null;
 };
 

--- a/lib/music_services/appleDef.js
+++ b/lib/music_services/appleDef.js
@@ -27,8 +27,18 @@ const appleDef = {
   tracks:    loadTracks,
   empty:     isEmpty,
   metadata:  getMetadata,
-  urimeta:   getURIandMetadata           
+  urimeta:   getURIandMetadata,
+  headers:   getHeaders,
+  authenticate: authenticateService
 }  
+
+function getHeaders() {
+  return null;
+};
+
+function authenticateService() {
+  return Promise.resolve();
+}
 
 function getURI(type, id) {
   if (type == 'album') {

--- a/lib/music_services/deezerDef.js
+++ b/lib/music_services/deezerDef.js
@@ -28,8 +28,18 @@ const deezerDef = {
   tracks:    loadTracks,
   empty:     isEmpty,
   metadata:  getMetadata,
-  urimeta:   getURIandMetadata           
-}  
+  urimeta:   getURIandMetadata,
+  headers:   getTokenHeaders,
+  authenticate: authenticateService
+}
+
+function getTokenHeaders() {
+  return null;
+}
+
+function authenticateService() {
+  return Promise.resolve();
+}
 
 function getURI(type, id) {
   if (type == 'album') {

--- a/lib/music_services/libraryDef.js
+++ b/lib/music_services/libraryDef.js
@@ -49,9 +49,18 @@ const libraryDef = {
   searchlib: searchLibrary,
   empty: isEmpty,
   metadata: getMetadata,
-  urimeta: getURIandMetadata
+  urimeta: getURIandMetadata,
+  headers: getTokenHeaders,
+  authenticate: authenticateService
 }
 
+function getTokenHeaders() {
+  return null;
+}
+
+function authenticateService() {
+  return Promise.resolve();
+}
 
 function setService(player, p_accountId, p_accountSN, p_country) {
 }

--- a/lib/music_services/spotifyDef.js
+++ b/lib/music_services/spotifyDef.js
@@ -1,4 +1,19 @@
 'use strict';
+
+var   request = require('request-promise');
+const settings = require('../../settings');
+
+var clientId = "";
+var clientSecret = "";
+
+try {
+  clientId = settings.spotify.clientId;
+  clientSecret = settings.spotify.clientSecret;
+} catch(e) {
+}
+
+var clientToken = null;
+
 const spotifyDef = {
   country:   '&market=',
   search:    {
@@ -31,8 +46,72 @@ const spotifyDef = {
   tracks:    loadTracks,
   empty:     isEmpty,
   metadata:  getMetadata,
-  urimeta:   getURIandMetadata           
-}  
+  urimeta:   getURIandMetadata,
+  headers:   getTokenHeaders,
+  authenticate: authenticateService,
+}
+
+var  toBase64 = (string) => new Buffer(string).toString('base64');
+
+const SPOTIFY_TOKEN_URL = 'https://accounts.spotify.com/api/token';
+
+const mapResponse = ({ access_token, token_type, expires_in }) => ({
+  accessToken: access_token,
+  tokenType: token_type,
+  expiresIn: expires_in,
+});
+
+const getHeaders = () => {
+console.log("clientId=" + clientId + "  clientSecret=" + clientSecret);
+  const authString = `${clientId}:${clientSecret}`;
+  return {
+    Authorization: `Basic ${toBase64(authString)}`,
+    'Content-Type': 'application/x-www-form-urlencoded',
+  };
+};
+
+const getOptions = (url) => {
+  return {
+    url,
+    headers: getHeaders(),
+    json: true,
+    method: 'POST',
+    form: {
+      grant_type: 'client_credentials',
+    },
+  };
+};
+
+const auth = () => {
+  const options = getOptions(SPOTIFY_TOKEN_URL);
+  return new Promise((resolve, reject) => {
+    request(options).then((response) => {
+      const responseMapped = mapResponse(response);
+      resolve(responseMapped);
+    }).catch((err) => {
+      reject(new Error(`Unable to authenticate Spotify with client id: ${clientId}`));
+    })
+  });
+};
+
+function getTokenHeaders() {
+  if (clientToken == null) {
+    return null;
+  }
+  return {
+    Authorization: `Bearer ${clientToken}`
+  };
+}
+
+function authenticateService() {
+  return new Promise((resolve, reject) => {
+    auth().then((response) => {
+      const { accessToken } = response;
+      clientToken = accessToken;
+      resolve();
+    }).catch(reject);
+  });
+}
 
 function getURI(type, id) {
   if (type == 'album') {

--- a/lib/music_services/spotifyDef.js
+++ b/lib/music_services/spotifyDef.js
@@ -62,7 +62,6 @@ const mapResponse = ({ access_token, token_type, expires_in }) => ({
 });
 
 const getHeaders = () => {
-console.log("clientId=" + clientId + "  clientSecret=" + clientSecret);
   const authString = `${clientId}:${clientSecret}`;
   return {
     Authorization: `Basic ${toBase64(authString)}`,


### PR DESCRIPTION
I took petersamuelsen's great work and slimmed it down to fewer file changes, kept the changes to just the musicSearch related files, and followed conventions used elsewhere in the app. I've tested all supported music services successfully.