### PR TITLE
Support for Amazon Music and a little fix for Apple Music

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,8 +791,8 @@ The following endpoints are available:
 /RoomName/applemusic/{now,next,queue}/album:{albumID}
 
 # Amazon Music
-/RoomName/applemusic/{now,next,queue}/song:{songID}
-/RoomName/applemusic/{now,next,queue}/album:{albumID}
+/RoomName/amazonmusic/{now,next,queue}/song:{songID}
+/RoomName/amazonmusic/{now,next,queue}/album:{albumID}
 ```
 
 It only handles a single **spotify** account currently. It will probably use the first account added on your system.

--- a/README.md
+++ b/README.md
@@ -773,7 +773,7 @@ adjust crossover frequency in hz. Official values are 50 through 110 in incremen
 `/TV%20Room/sub/polarity/1`
 Switch "placement adjustment" or more commonly known as phase. 0 = 0°, 1 = 180°
 
-Spotify and Apple Music (Experimental)
+Spotify, Apple Music and Amazon Music (Experimental)
 ----------------------
 
 Allows you to perform your own external searches for Apple Music or Spotify songs or albums and play a specified song or track ID. The Music Search funtionality outlined further below performs a search of its own and plays the specified music.
@@ -789,12 +789,44 @@ The following endpoints are available:
 # Apple Music
 /RoomName/applemusic/{now,next,queue}/song:{songID}
 /RoomName/applemusic/{now,next,queue}/album:{albumID}
+
+# Amazon Music
+/RoomName/applemusic/{now,next,queue}/song:{songID}
+/RoomName/applemusic/{now,next,queue}/album:{albumID}
 ```
+
+It only handles a single spotify account currently. It will probably use the first account added on your system.
 
 You can find Apple Music song and album IDs via the [iTunes Search
 API](https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/).
 
-It only handles a single spotify account currently. It will probably use the first account added on your system.
+You can also use iTunes to figure out song and album IDs. Right click on a song or album and select "Share" -> "Copy Link". You can do this when you searched within Apple Music or from your media library as long as the song is available in Apple Music.
+
+Have a look at the link you just copied. 
+
+* If you shared the link to a song
+The format is: https://itunes.apple.com/de/album/*{songName}*/*{albumID}*?i=*{songID}*
+
+eg: https://itunes.apple.com/de/album/blood-of-my-enemies/355363490?i=355364259
+
+* If you shared the link to an album
+The format is: https://itunes.apple.com/de/album/*{albumName}*/*{albumID}*
+
+eg: https://itunes.apple.com/de/album/f-g-restless/355363490
+
+To find Amazon Music song and album IDs you can use the Amazon Music App, search for a song or an album and share a link.
+
+Look at the link you just shared.
+
+* If you shared the link to a song
+The format is: https://music.amazon.de/albums/*{albumID}*?trackAsin=*{songID}*&ref=dm_sh_d74d-4daa-dmcp-63cb-e8747&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
+
+eg: https://music.amazon.de/albums/B0727SH7LW?trackAsin=B071918VCR&ref=dm_sh_d74d-4daa-dmcp-63cb-e8747&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
+
+* If you shared the link to an album
+The format is: https://music.amazon.de/albums/*{albumID}*?ref=dm_sh_97aa-255b-dmcp-c6ba-4ff00&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
+
+eg: https://music.amazon.de/albums/B0727SH7LW?ref=dm_sh_97aa-255b-dmcp-c6ba-4ff00&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
 
 
 SiriusXM

--- a/README.md
+++ b/README.md
@@ -806,13 +806,11 @@ Have a look at the link you just copied.
 
 *If you shared the link to a song:*
 The format is: https://itunes.apple.com/de/album/{songName}/{albumID}?i={songID}
-
-eg: https://itunes.apple.com/de/album/blood-of-my-enemies/355363490?i=355364259
+> eg: https://itunes.apple.com/de/album/blood-of-my-enemies/355363490?i=355364259
 
 *If you shared the link to an album:*
 The format is: https://itunes.apple.com/de/album/{albumName}/{albumID}
-
-eg: https://itunes.apple.com/de/album/f-g-restless/355363490
+> eg: https://itunes.apple.com/de/album/f-g-restless/355363490
 
 To find **Amazon Music** song and album IDs you can use the Amazon Music App, search for a song or an album and share a link.
 
@@ -820,11 +818,11 @@ Look at the link you just shared.
 
 *If you shared the link to a song:*
 The format is: https://music.amazon.de/albums/{albumID}?trackAsin={songID}&ref=dm_sh_d74d-4daa-dmcp-63cb-e8747&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
-eg: https://music.amazon.de/albums/B0727SH7LW?trackAsin=B071918VCR&ref=dm_sh_d74d-4daa-dmcp-63cb-e8747&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
+> eg: https://music.amazon.de/albums/B0727SH7LW?trackAsin=B071918VCR&ref=dm_sh_d74d-4daa-dmcp-63cb-e8747&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
 
 *If you shared the link to an album:*
 The format is: https://music.amazon.de/albums/{albumID}?ref=dm_sh_97aa-255b-dmcp-c6ba-4ff00&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
-eg: https://music.amazon.de/albums/B0727SH7LW?ref=dm_sh_97aa-255b-dmcp-c6ba-4ff00&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
+> eg: https://music.amazon.de/albums/B0727SH7LW?ref=dm_sh_97aa-255b-dmcp-c6ba-4ff00&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
 
 
 SiriusXM

--- a/README.md
+++ b/README.md
@@ -814,7 +814,7 @@ The format is: https://itunes.apple.com/de/album/{albumName}/{albumID}
 
 To find **Amazon Music** song and album IDs you can use the Amazon Music App, search for a song or an album and share a link.
 
-Look at the link you just shared.
+Look at the link you just shared. This works with Amazon Music Prime as well as with Amazon Music Prime which is included in your Amazon Prime membership. 
 
 *If you shared the link to a song:*
 The format is: https://music.amazon.de/albums/{albumID}?trackAsin={songID}&ref=dm_sh_d74d-4daa-dmcp-63cb-e8747&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9

--- a/README.md
+++ b/README.md
@@ -819,13 +819,11 @@ To find Amazon Music song and album IDs you can use the Amazon Music App, search
 Look at the link you just shared.
 
 * If you shared the link to a song
-The format is: https://music.amazon.de/albums/*{albumID}*?trackAsin=*{songID}*&ref=dm_sh_d74d-4daa-dmcp-63cb-e8747&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
-
+The format is: https://music.amazon.de/albums/{albumID}?trackAsin={songID}&ref=dm_sh_d74d-4daa-dmcp-63cb-e8747&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
 eg: https://music.amazon.de/albums/B0727SH7LW?trackAsin=B071918VCR&ref=dm_sh_d74d-4daa-dmcp-63cb-e8747&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
 
 * If you shared the link to an album
-The format is: https://music.amazon.de/albums/*{albumID}*?ref=dm_sh_97aa-255b-dmcp-c6ba-4ff00&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
-
+The format is: https://music.amazon.de/albums/{albumID}?ref=dm_sh_97aa-255b-dmcp-c6ba-4ff00&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
 eg: https://music.amazon.de/albums/B0727SH7LW?ref=dm_sh_97aa-255b-dmcp-c6ba-4ff00&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
 
 

--- a/README.md
+++ b/README.md
@@ -795,34 +795,34 @@ The following endpoints are available:
 /RoomName/applemusic/{now,next,queue}/album:{albumID}
 ```
 
-It only handles a single spotify account currently. It will probably use the first account added on your system.
+It only handles a single **spotify** account currently. It will probably use the first account added on your system.
 
-You can find Apple Music song and album IDs via the [iTunes Search
+You can find **Apple Music** song and album IDs via the [iTunes Search
 API](https://affiliate.itunes.apple.com/resources/documentation/itunes-store-web-service-search-api/).
 
 You can also use iTunes to figure out song and album IDs. Right click on a song or album and select "Share" -> "Copy Link". You can do this when you searched within Apple Music or from your media library as long as the song is available in Apple Music.
 
 Have a look at the link you just copied. 
 
-* If you shared the link to a song
-The format is: https://itunes.apple.com/de/album/*{songName}*/*{albumID}*?i=*{songID}*
+*If you shared the link to a song:*
+The format is: https://itunes.apple.com/de/album/{songName}/{albumID}?i={songID}
 
 eg: https://itunes.apple.com/de/album/blood-of-my-enemies/355363490?i=355364259
 
-* If you shared the link to an album
-The format is: https://itunes.apple.com/de/album/*{albumName}*/*{albumID}*
+*If you shared the link to an album:*
+The format is: https://itunes.apple.com/de/album/{albumName}/{albumID}
 
 eg: https://itunes.apple.com/de/album/f-g-restless/355363490
 
-To find Amazon Music song and album IDs you can use the Amazon Music App, search for a song or an album and share a link.
+To find **Amazon Music** song and album IDs you can use the Amazon Music App, search for a song or an album and share a link.
 
 Look at the link you just shared.
 
-* If you shared the link to a song
+*If you shared the link to a song:*
 The format is: https://music.amazon.de/albums/{albumID}?trackAsin={songID}&ref=dm_sh_d74d-4daa-dmcp-63cb-e8747&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
 eg: https://music.amazon.de/albums/B0727SH7LW?trackAsin=B071918VCR&ref=dm_sh_d74d-4daa-dmcp-63cb-e8747&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
 
-* If you shared the link to an album
+*If you shared the link to an album:*
 The format is: https://music.amazon.de/albums/{albumID}?ref=dm_sh_97aa-255b-dmcp-c6ba-4ff00&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
 eg: https://music.amazon.de/albums/B0727SH7LW?ref=dm_sh_97aa-255b-dmcp-c6ba-4ff00&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
 

--- a/lib/actions/amazonMusic.js
+++ b/lib/actions/amazonMusic.js
@@ -1,0 +1,74 @@
+'use strict';
+function getMetadata(id, parentUri, type, title) {
+return `<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/" xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
+<item id="${id}" parentID="${parentUri}" restricted="true">
+  <dc:title>"${title}"</dc:title>
+  <upnp:class>${type}</upnp:class>
+  <desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON51463_X_#Svc51463-0-Token</desc>
+</item>
+</DIDL-Lite>`;
+}
+
+function getSongUri(id) {
+  return `x-sonosapi-hls-static:catalog%2ftracks%2f${id}%2f%3falbumAsin%3dB01JDKZWK0?sid=201&flags=0&sn=4`;
+}
+
+function getAlbumUri(id) {
+  return `x-rincon-cpcontainer:1004206ccatalog%2falbums%2f${id}%2f%23album_desc?sid=201&flags=8300&sn=4`;
+}
+
+const uriTemplates = {
+  song: getSongUri,
+  album: getAlbumUri
+};
+
+const CLASSES = {
+  song: 'object.container.album.musicAlbum.#AlbumView',
+  album: 'object.container.album.musicAlbum'
+};
+
+const METADATA_URI_STARTERS = {
+  song: '10030000catalog%2ftracks%2f',
+  album: '1004206ccatalog'
+};
+
+const METADATA_URI_ENDINGS = {
+  song: '%2f%3falbumAsin%3d',
+  album: '%2f%23album_desc'
+};
+
+
+const PARENTS = {
+  song: '1004206ccatalog%2falbums%2f',
+  album: '10052064catalog%2fartists%2f'
+};
+
+function amazonMusic(player, values) {
+  const action = values[0];
+  const track = values[1];
+  const type = track.split(':')[0];
+  const trackID = track.split(':')[1];
+
+  var nextTrackNo = 0;
+
+  const metadataID = METADATA_URI_STARTERS[type] + encodeURIComponent(trackID) + METADATA_URI_ENDINGS[type];
+
+  const metadata = getMetadata(metadataID, PARENTS[type], CLASSES[type], '');
+  const uri = uriTemplates[type](encodeURIComponent(trackID));
+
+  if (action == 'queue') {
+    return player.coordinator.addURIToQueue(uri, metadata);
+  } else if (action == 'now') {
+    nextTrackNo = player.coordinator.state.trackNo + 1;
+    return player.coordinator.addURIToQueue(uri, metadata, true, nextTrackNo)
+      .then(() => { if (nextTrackNo != 1) player.coordinator.nextTrack() })
+      .then(() => player.coordinator.play());
+  } else if (action == 'next') {
+    nextTrackNo = player.coordinator.state.trackNo + 1;
+    return player.coordinator.addURIToQueue(uri, metadata, true, nextTrackNo);
+  }
+}
+
+module.exports = function (api) {
+  api.registerAction('amazonmusic', amazonMusic);
+};

--- a/lib/actions/appleMusic.js
+++ b/lib/actions/appleMusic.js
@@ -49,7 +49,7 @@ function appleMusic(player, values) {
   } else if (action == 'now') {
     nextTrackNo = player.coordinator.state.trackNo + 1;
     return player.coordinator.addURIToQueue(uri, metadata, true, nextTrackNo)
-      .then(() => player.coordinator.nextTrack())
+      .then(() => { if (nextTrackNo != 1) player.coordinator.nextTrack() })
       .then(() => player.coordinator.play());
   } else if (action == 'next') {
     nextTrackNo = player.coordinator.state.trackNo + 1;


### PR DESCRIPTION
I added support for Amazon Music.

I was wondering why http://127.0.0.1:5005/Kinderzimmer/applemusic/now/album:1139304556 always jumped the the 2nd song of the album. 

I found the reason and fixed it. Only if the queue is not empty you must skip to the next song. If it is empty then just play the current song.

The documentation was changed to include Amazon Music support and I found some new ways to figure out song and album ID. I wrote them down in the README.md
