### PR TITLE
Add ip setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ If you want to change default settings, you can create a settings.json file and 
 Available options are:
 
 * port: change the listening port
+* ip: change the listening IP
 * https: use https which requires a key and certificate or pfx file
 * auth: require basic auth credentials which requires a username and password
 * announceVolume: the percentual volume use when invoking say/sayall without any volume parameter
@@ -328,6 +329,7 @@ Example:
 	    "name": "ZiraRUS"
 	  },
 	  "port": 5005,
+	  "ip": "0.0.0.0",
 	  "securePort": 5006,
 	  "https": {
 	    "key": "/path/to/key.pem",

--- a/server.js
+++ b/server.js
@@ -80,9 +80,9 @@ process.on('unhandledRejection', (err) => {
   logger.error(err);
 });
 
-let host = settings.ip || "0.0.0.0";
+let host = settings.ip;
 server.listen(settings.port, host, function () {
-  logger.info('http server listening on port', settings.port);
+  logger.info('http server listening on', host, 'port', settings.port);
 });
 
 server.on('error', (err) => {

--- a/server.js
+++ b/server.js
@@ -80,7 +80,8 @@ process.on('unhandledRejection', (err) => {
   logger.error(err);
 });
 
-server.listen(settings.port, function () {
+let host = settings.ip || "0.0.0.0";
+server.listen(settings.port, host, function () {
   logger.info('http server listening on port', settings.port);
 });
 

--- a/settings.js
+++ b/settings.js
@@ -16,6 +16,7 @@ function merge(target, source) {
 
 var settings = {
   port: 5005,
+  ip: "0.0.0.0",
   securePort: 5006,
   cacheDir: path.resolve(__dirname, 'cache'),
   webroot: path.resolve(__dirname, 'static'),


### PR DESCRIPTION
This patch simply allows the user to provide an "ip" setting in `settings.json`, which will bind the main API server listener to that IP.

I run Node Sonos HTTP API in a Docker container on a host with multiple IP addresses, where each container typically binds to a specific IP. Docker and Docker Compose currently have no way to specify an _outgoing_ IP to bind a container to; the bridge network uses masquerade and there is no built-in way to change how that routing functions.

Sonos requires multicast and other "hard to forward" network connections, so the Docker network type of "host" is recommended. This is fine for all of the Sonos stuff because it uses very unique port ranges, NetBIOS, and uPnP, which are unlikely to be needed by another specific container.

However, if you want to use ports 80 and/or 443 for the API server itself, binding to 0.0.0.0 will conflict with any other process using that port. Indeed, Sonos API requests are served through the machine's default IP as well.

By specifying that the API server bind to a specific IP address, you can use host network mode in Docker, share the NetBIOS, uPnP, and Sonos discovery traffic across the physical interface, but constrain common web traffic to one IP only so that all of your web apps can live in harmony.