### PR TITLE
Add support for Balance, Loudness and Surround

### DIFF
--- a/lib/actions/equalizer.js
+++ b/lib/actions/equalizer.js
@@ -20,9 +20,15 @@ function treble(player, values) {
   return player.setTreble(level);
 }
 
+function loudness(player, values) {
+  const enable = values[0] === 'on';
+  return player.setLoudness(enable);
+}
+
 module.exports = function (api) {
   api.registerAction('nightmode', nightMode);
   api.registerAction('speechenhancement', speechEnhancement);
   api.registerAction('bass', bass);
   api.registerAction('treble', treble);
+  api.registerAction('loudness', loudness);
 }

--- a/lib/actions/equalizer.js
+++ b/lib/actions/equalizer.js
@@ -25,10 +25,16 @@ function loudness(player, values) {
   return player.setLoudness(enable);
 }
 
+function balance(player, values) {
+  const balance = parseInt(values[0]);
+  return player.setBalance(balance);
+}
+ 
 module.exports = function (api) {
   api.registerAction('nightmode', nightMode);
   api.registerAction('speechenhancement', speechEnhancement);
   api.registerAction('bass', bass);
   api.registerAction('treble', treble);
   api.registerAction('loudness', loudness);
+  api.registerAction('balance', balance); 
 }

--- a/lib/actions/equalizer.js
+++ b/lib/actions/equalizer.js
@@ -25,16 +25,10 @@ function loudness(player, values) {
   return player.setLoudness(enable);
 }
 
-function balance(player, values) {
-  const balance = parseInt(values[0]);
-  return player.setBalance(balance);
-}
- 
 module.exports = function (api) {
   api.registerAction('nightmode', nightMode);
   api.registerAction('speechenhancement', speechEnhancement);
   api.registerAction('bass', bass);
   api.registerAction('treble', treble);
   api.registerAction('loudness', loudness);
-  api.registerAction('balance', balance); 
 }

--- a/lib/actions/surround.js
+++ b/lib/actions/surround.js
@@ -8,11 +8,8 @@ function surround(player, values) {
   const action = values[0];
   const value = values[1];
 
-  return player.setSurround(action, value)
+  return player.setSurround(action, value);
 
-  return Promise.resolve({
-    message: 'Valid options are on, off, mode, level, musiclevel'
-  });
 }
 
 module.exports = function (api) {

--- a/lib/actions/surround.js
+++ b/lib/actions/surround.js
@@ -1,0 +1,20 @@
+'use strict';
+
+function surround(player, values) {
+  if (!player.hasSurround) {
+    return Promise.reject(new Error('This zone doesn\'t have Surround'));
+  }
+
+  const action = values[0];
+  const value = values[1];
+
+  return player.setSurround(action, value)
+
+  return Promise.resolve({
+    message: 'Valid options are on, off, mode, level, musiclevel'
+  });
+}
+
+module.exports = function (api) {
+  api.registerAction('surround', surround);
+}

--- a/lib/actions/volume.js
+++ b/lib/actions/volume.js
@@ -1,9 +1,21 @@
 'use strict';
 
 function volume(player, values) {
-  var volume = values[0];
-  var channel = values[1] || 'Master';
+  let channel;
+  let volume;
+  if (/^\d+$/i.test(values[0])) {
+    channel = 'Master';
+    volume = values[0];
+  } else {
+    channel = values[0];
+    volume = values[1];
+  }
   return player.setVolume(volume, channel);
+}
+
+function balance(player, values) {
+  let level = values[0];
+  return player.setBalance(level);
 }
 
 function groupVolume(player, values) {
@@ -12,5 +24,6 @@ function groupVolume(player, values) {
 
 module.exports = function (api) {
   api.registerAction('volume', volume);
+  api.registerAction('balance', balance);
   api.registerAction('groupvolume', groupVolume);
 }

--- a/lib/actions/volume.js
+++ b/lib/actions/volume.js
@@ -1,7 +1,9 @@
 'use strict';
+
 function volume(player, values) {
   var volume = values[0];
-  return player.setVolume(volume);
+  var channel = values[1] || 'Master';
+  return player.setVolume(volume, channel);
 }
 
 function groupVolume(player, values) {


### PR DESCRIPTION
This is the syntax of new functions intended to manage LF and RF Volume, Balance, Loudness and Surrounds options:

- http://localhost:5005/{room name}/volume/{Master (default) | LF | RF}/{volume | relative volume}
- http://localhost:5005/{room name}/balance/{integer between -100 and  100}
- http://localhost:5005/{room name}/loudness/{on | off}
- http://localhost:5005/{room name}/surround/{on | off}
- http://localhost:5005/{room name}/surround/mode/{ambient | 0 | full | 1}
- http://localhost:5005/{room name}/surround/level/{integer between -15 and  15}
- http://localhost:5005/{room name}/surround/musiclevel/{integer between -15 and  15}