### PR TITLE
Wrap decoding of player name in try/catch to avoid server from crashing on malformed uri

### DIFF
--- a/lib/sonos-http-api.js
+++ b/lib/sonos-http-api.js
@@ -60,8 +60,15 @@ function HttpAPI(discovery, settings) {
     }
 
     const params = req.url.substring(1).split('/');
-
-    let player = discovery.getPlayer(decodeURIComponent(params[0]));
+    
+    // parse decode player name considering decode errors
+    let player;
+    try {
+      player = discovery.getPlayer(decodeURIComponent(params[0]));
+    } catch (error) {
+      logger.error(`Unable to parse supplied URI component (${params[0]})`, error);
+      return sendResponse(500, { status: 'error', error: error.message, stack: error.stack });
+    }
 
     const opt = {};
 


### PR DESCRIPTION
Hey -- some of my players have national characters in them and while writing a script to join/leave players I found that sending a malformed encoded name would cause the node app to crash. This commit simply wraps the decode of the player name in a try/catch to log the error but not crash the node app.