### PR TITLE
Fix for Sirius XM account ID problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,9 @@ Example:
 	    "username": "your-pandora-account-email-address",
 	    "password": "your-pandora-password"
 	  },
+	  "siriusxm": {
+	    "accountid": "your-siriusxm-account-id"
+	  },
 	  "spotify": {
 	    "clientId": "your-spotify-application-clientId",
 	    "clientSecret": "your-spotify-application-clientSecret"

--- a/lib/actions/siriusXM.js
+++ b/lib/actions/siriusXM.js
@@ -2,6 +2,7 @@
 const request = require('request-promise');
 const Fuse = require('fuse.js');
 const channels = require('../sirius-channels.json');
+const settings = require('../../settings');
 
 var accountId = '';
 
@@ -25,24 +26,6 @@ function adjustStation(name) {
     name = name.replace(replaceArray[i].split('|')[0],replaceArray[i].split('|')[1]);
 
   return name;
-}
-
-function getAccountId(player)
-{
-  accountId = '';
- 
-  return request({url: player.baseUrl + '/status/accounts',json: false})
-    .then((res) => {
-      var actLoc = res.indexOf('Account Type="9479"');
-       
-      if (actLoc != -1) {
-        var idLoc = res.indexOf('<UN>', actLoc)+4;
-  
-        accountId = res.substring(idLoc,res.indexOf('</UN>',idLoc));
-      }
-        
-      return Promise.resolve();
-    });
 }
 
 function siriusXM(player, values) {
@@ -87,23 +70,20 @@ function siriusXM(player, values) {
   } else {
   // Play the specified SiriusXM channel or station
 
-    return getAccountId(player)
-    .then(() => {
-      if (accountId != '') {
-        var searchVal = values[0];
-        var fuzzy = new Fuse(channels, { keys: ["channelNum", "title"] });
+    if (settings.siriusxm.accountid != '') {
+      var searchVal = values[0];
+      var fuzzy = new Fuse(channels, { keys: ["channelNum", "title"] });
 
-        results = fuzzy.search(searchVal);
-        if (results.length > 0) {
-          const channel = results[0];
-          const uri = getSiriusXmUri(channel.id);
-          const metadata = getSiriusXmMetadata(channel.id, channel.parentID, channel.fullTitle, accountId);
+      results = fuzzy.search(searchVal);
+      if (results.length > 0) {
+        const channel = results[0];
+        const uri = getSiriusXmUri(channel.id);
+        const metadata = getSiriusXmMetadata(channel.id, channel.parentID, channel.fullTitle, settings.siriusxm.accountid);
 
-          return player.coordinator.setAVTransport(uri, metadata)
-            .then(() => player.coordinator.play());
-        }
+        return player.coordinator.setAVTransport(uri, metadata)
+          .then(() => player.coordinator.play());
       }
-    });
+    }
   }
 }
 


### PR DESCRIPTION
The way the account id was retrieved automatically no longer works due to a change that came with 8.3. Modified the code so that the account ID can be specified in the settings.json file and retrieved from there.