### PR TITLE
Add stop command for reliable systemd shutdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A simple node app for controlling a Sonos system with basic HTTP requests",
   "scripts": {
     "start": "node server.js",
+    "stop": "pkill nodesonoshttp",
     "lint": "eslint lib"
   },
   "author": "Jimmy Shimizu <jimmy@shimizu.se>",

--- a/server.js
+++ b/server.js
@@ -1,4 +1,6 @@
 'use strict';
+process.title = "nodesonoshttp";
+
 const http = require('http');
 const https = require('https');
 const fs = require('fs');


### PR DESCRIPTION
Thanks for your work on this package!

I've found that running node-sonos-http-api through a systemd service occasionally results in the process "running away" such that systemd can no longer stop or restart it for config-changes or deployments. I doubt this is a bug in node-sonos-http-api (but fwiw this doesn't happen with simple express.js apps running with the same systemd configs).

I am not an expert in systemd or node, but I've found out that adding a `npm run stop` command solves the issue very reliably and without any real downside that I can see. The `stop` command just does a `pkill` of the server using its symbolic process name which is now set at the top of the server.js file.

I've been running with this change for several days and have not had any more "zombie" processes. Contributing this back in case it helps others in the future.
