### PR TITLE
Fixing Pandora to work again because of Sonos changes as well as a minor tweak to Spotify

### DIFF
--- a/lib/actions/pandora.js
+++ b/lib/actions/pandora.js
@@ -109,11 +109,14 @@ function pandora(player, values) {
     if (cmd == 'play') {
       return playPandora(player, values[1]);
     } if ((cmd == 'thumbsup')||(cmd == 'thumbsdown')) {
+
+      var sid = player.system.getServiceId('Pandora');
       const uri = player.state.currentTrack.uri;
    
-      if (uri.startsWith('pndrradio-http')) {
-        const stationToken = uri.substring(uri.search('&x=') + 3);
-        const trackToken = uri.substring(uri.search('&m=') + 3,uri.search('&f='));
+      if (uri.startsWith('x-sonosapi-radio') && uri.search(`sid=${sid}`) != -1 && player.state.currentTrack.trackUri) {
+        const trackUri = player.state.currentTrack.trackUri;
+        const trackToken = trackUri.substring(trackUri.search('x-sonos-http:') + 13, trackUri.search('%3a%3aST%3a'));
+        const stationToken = trackUri.substring(trackUri.search('%3a%3aST%3a') + 11, trackUri.search('%3a%3aRINCON'));
         const up = (cmd == 'thumbsup');
 
         return userLogin()

--- a/lib/actions/pandora.js
+++ b/lib/actions/pandora.js
@@ -4,21 +4,16 @@ const Anesidora = require("anesidora");
 const Fuse = require('fuse.js');
 const settings = require('../../settings');
 
-function getPandoraMetadata(id, title, auth) {
+function getPandoraMetadata(id, title, serviceType) {
   return `<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"
         xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/" xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
-        <item id="OOOX${id}" parentID="0" restricted="true"><dc:title>${title}</dc:title><upnp:class>object.item.audioItem.audioBroadcast</upnp:class>
-        <desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON3_${auth}</desc></item></DIDL-Lite>`;
+        <item id="100c206cST%3a${id}" parentID="0" restricted="true"><dc:title>${title}</dc:title><upnp:class>object.item.audioItem.audioBroadcast.#station</upnp:class>
+        <desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">SA_RINCON${serviceType}_X_#Svc${serviceType}-0-Token</desc></item></DIDL-Lite>`;
 }
 
 function getPandoraUri(id, title, albumart) {
-  if (albumart == undefined) {
-    return `pndrradio:${id}?sn=2`;
-  } else {
-    return `pndrradio:${id}?sn=2,"title":"${title}","albumArtUri":"${albumart}"`;
-  }  
+  return `x-sonosapi-radio:ST%3a${id}?sid=236&flags=8300&sn=1`;
 }
-
 
 function pandora(player, values) {
   const cmd = values[0];
@@ -52,6 +47,8 @@ function pandora(player, values) {
   function playPandora(player, name) {
     var uri = '';
     var metadata = '';
+
+    var sid = player.system.getServiceId('Pandora');
 
     return userLogin()
       .then(() => pandoraAPI("user.getStationList", {"includeStationArtUrl" : true}))
@@ -87,13 +84,13 @@ function pandora(player, values) {
               const station = results[0];
               if (station.type == undefined) {
                 uri = getPandoraUri(station.stationId, station.stationName, station.artUrl);
-                metadata = getPandoraMetadata(station.stationId, station.stationName, settings.pandora.username);
+                metadata = getPandoraMetadata(station.stationId, station.stationName, player.system.getServiceType('Pandora'));
                 return Promise.resolve();
               } else {
                 return pandoraAPI("station.createStation", {"musicToken":station.stationId, "musicType":station.type})
                   .then((stationInfo) => {
                   	 uri = getPandoraUri(stationInfo.stationId);
-                     metadata = getPandoraMetadata(stationInfo.stationId, stationInfo.stationName, settings.pandora.username);
+                     metadata = getPandoraMetadata(stationInfo.stationId, stationInfo.stationName, player.system.getServiceType('Pandora'));
                      return Promise.resolve();
                   });
               }

--- a/lib/music_services/spotifyDef.js
+++ b/lib/music_services/spotifyDef.js
@@ -146,7 +146,7 @@ function setService(player, p_accountId, p_accountSN, p_country)
   sid = player.system.getServiceId('Spotify');
   serviceType = player.system.getServiceType('Spotify');
   accountId = p_accountId;
-  accountSN = p_accountSN;
+  accountSN = 14; // GACALD: Hack to fix Spotify p_accountSN; 
   country = p_country;
 }
 


### PR DESCRIPTION
Pandora integration is very different so I fixed the auth token and switched over to the new URI.  Spotify no longer can get its sn from an http call to the device.  It doesn't exist.

Note: This requires my change to node-sonos-discovery to keep the track uri for Pandora.