### PR TITLE
Fix possible crash on /musicsearch/spotify/song/ related to available markets

### DIFF
--- a/lib/music_services/spotifyDef.js
+++ b/lib/music_services/spotifyDef.js
@@ -226,7 +226,7 @@ function loadTracks(type, tracksJson)
   if (tracksJson.tracks.items.length > 0) {
     // Filtered list of tracks to play
     tracks.queueTracks = tracksJson.tracks.items.reduce(function(tracksArray, track) {
-      if (track.available_markets.indexOf(country) != -1) {
+      if (track.available_markets == null || track.available_markets.indexOf(country) != -1) {
         var skip = false;
   
         for (var j=0; (j < tracksArray.length) && !skip ; j++) {


### PR DESCRIPTION
When I used
'http://localhost:5005/Office/musicsearch/spotify/song/red+hot+chili+peppers'
straight from the docs, it was crashing because there was no
"track.available_markets" data.

This may be because I specifed a non-commercial app when I generated my
spotify clientId + secret?  Anyway, this forgoes the available_markets
checking if the data is not there.