### PR TITLE
VoiceRSS: Force creation of MP3 instead of WAV file to play with Sonos

### DIFF
--- a/lib/tts-providers/voicerss.js
+++ b/lib/tts-providers/voicerss.js
@@ -16,7 +16,8 @@ function voicerss(phrase, language) {
     language = 'en-gb';
   }
   // Use voicerss tts translation service to create a mp3 file
-  const ttsRequestUrl = `http://api.voicerss.org/?key=${settings.voicerss}&f=22khz_16bit_mono&hl=${language}&src=${encodeURIComponent(phrase)}`;
+  // Option "c=MP3" added. Otherwise a WAV file is created that won't play on Sonos.
+  const ttsRequestUrl = `http://api.voicerss.org/?key=${settings.voicerss}&f=22khz_16bit_mono&hl=${language}&src=${encodeURIComponent(phrase)}&c=MP3`;
 
   // Construct a filesystem neutral filename
   const phraseHash = crypto.createHash('sha1').update(phrase).digest('hex');


### PR DESCRIPTION
Latest VoiceRSS requires explicit option to create MP3 file instead of default WAV file.
See issue https://github.com/jishi/node-sonos-http-api/issues/686