### PR TITLE
Adding basic SSML support to Polly

### DIFF
--- a/lib/tts-providers/aws-polly.js
+++ b/lib/tts-providers/aws-polly.js
@@ -23,6 +23,9 @@ function polly(phrase, voiceName) {
   // Construct a filesystem neutral filename
   const dynamicParameters = { Text: phrase };
   const synthesizeParameters = Object.assign({}, DEFAULT_SETTINGS, dynamicParameters);
+  if (phrase.startsWith('<speak>') && phrase.endsWith('</speak>')) {
+    synthesizeParameters.textType = 'ssml';
+  }
   if (settings.aws.name) {
     synthesizeParameters.VoiceId = settings.aws.name;
   }

--- a/lib/tts-providers/aws-polly.js
+++ b/lib/tts-providers/aws-polly.js
@@ -24,7 +24,7 @@ function polly(phrase, voiceName) {
   const dynamicParameters = { Text: phrase };
   const synthesizeParameters = Object.assign({}, DEFAULT_SETTINGS, dynamicParameters);
   if (phrase.startsWith('<speak>') && phrase.endsWith('</speak>')) {
-    synthesizeParameters.textType = 'ssml';
+    synthesizeParameters.TextType = 'ssml';
   }
   if (settings.aws.name) {
     synthesizeParameters.VoiceId = settings.aws.name;


### PR DESCRIPTION
I recognized that the API basically could support SSML for AWS Polly. 
The phrase of course has to encode all the SSML tags, so that a phrase like
`<speak><prosody rate="90%">Hello</prosody></speak>`
has to be sent as
`http://mysonos:5005/Office/say/%3Cspeak%3E%3Cprosody%20rate%3D%2290%25%22%3EHello%3C%2Fprosody%3E%3C%2Fspeak%3E`

Nevertheless, the phrase is sent correctly to AWS, the only "showstopper" is that in the AWS API call, the TextType is set to text.

I now added a few simple lines in the aws-polly.js provider, detecting the leading and ending "<speak>" tags in an SSML phrase and setting the TextType to "ssml" accordingly.

