### PR TITLE
Restrict/allow concurrent '...all' actions

### DIFF
--- a/lib/helpers/all-player-announcement.js
+++ b/lib/helpers/all-player-announcement.js
@@ -39,90 +39,99 @@ function saveAll(system) {
 }
 
 function announceAll(system, uri, volume, duration) {
-  let abortTimer;
+  if (!(restrictParallelAnnouncements && announceAllActive)) {
+    // total time to group + play announcement + restore
+    const announceAllActiveTimeout = duration + systemGroupUngroupDuration;
+    announceAllActive = setTimeout(allPresetsRestored, announceAllActiveTimeout);
 
-  // Save all players
-  var backupPresets = saveAll(system);
+    let abortTimer;
 
-  // find biggest group and all players
-  const allPlayers = [];
-  let biggestZone = {};
-  system.zones.forEach(function (zone) {
-    if (!biggestZone.members || zone.members.length > biggestZone.members.length) {
-      biggestZone = zone;
-    }
-  });
+    // Save all players
+    var backupPresets = saveAll(system);
 
-  const coordinator = biggestZone.coordinator;
-
-  allPlayers.push({ roomName: coordinator.roomName, volume });
-
-  system.players.forEach(player => {
-    if (player.uuid == coordinator.uuid) return;
-    allPlayers.push({ roomName: player.roomName, volume });
-  });
-
-  const preset = {
-    uri,
-    players: allPlayers,
-    playMode: {
-      repeat: false
-    },
-    pauseOthers: true,
-    state: 'STOPPED'
-  };
-
-  const oneGroupPromise = new Promise((resolve) => {
-    const onTopologyChanged = (topology) => {
-      if (topology.length === 1) {
-        return resolve();
+    // find biggest group and all players
+    const allPlayers = [];
+    let biggestZone = {};
+    system.zones.forEach(function (zone) {
+      if (!biggestZone.members || zone.members.length > biggestZone.members.length) {
+        biggestZone = zone;
       }
-      // Not one group yet, continue listening
-      system.once('topology-change', onTopologyChanged);
-    };
-
-    system.once('topology-change', onTopologyChanged);
-  });
-
-  const restoreTimeout = duration + 2000;
-  return system.applyPreset(preset)
-    .then(() => {
-      if (system.zones.length === 1) return;
-      return oneGroupPromise;
-    })
-    .then(() => {
-      coordinator.play();
-      return new Promise((resolve) => {
-        const transportChange = (state) => {
-          logger.debug(`Player changed to state ${state.playbackState}`);
-          if (state.playbackState === 'STOPPED') {
-            return resolve();
-          }
-
-          coordinator.once('transport-state', transportChange);
-        };
-        setTimeout(() => {
-          coordinator.once('transport-state', transportChange);
-        }, duration / 2);
-
-        logger.debug(`Setting restore timer for ${restoreTimeout} ms`);
-        abortTimer = setTimeout(resolve, restoreTimeout);
-      });
-    })
-    .then(() => {
-      clearTimeout(abortTimer);
-    })
-    .then(() => {
-      return backupPresets.reduce((promise, preset) => {
-        logger.trace('Restoring preset', preset);
-        return promise.then(() => system.applyPreset(preset));
-      }, Promise.resolve());
-    })
-    .catch((err) => {
-      logger.error(err.stack);
-      throw err;
     });
 
+    const coordinator = biggestZone.coordinator;
+
+    allPlayers.push({ roomName: coordinator.roomName, volume });
+
+    system.players.forEach(player => {
+      if (player.uuid == coordinator.uuid) return;
+      allPlayers.push({ roomName: player.roomName, volume });
+    });
+
+    const preset = {
+      uri,
+      players: allPlayers,
+      playMode: {
+        repeat: false
+      },
+      pauseOthers: true,
+      state: 'STOPPED'
+    };
+
+    const oneGroupPromise = new Promise((resolve) => {
+      const onTopologyChanged = (topology) => {
+        if (topology.length === 1) {
+          return resolve();
+        }
+        // Not one group yet, continue listening
+        system.once('topology-change', onTopologyChanged);
+      };
+
+      system.once('topology-change', onTopologyChanged);
+    });
+
+    const restoreTimeout = duration + 2000;
+      return system.applyPreset(preset)
+      .then(() => {
+        if (system.zones.length === 1) return;
+        return oneGroupPromise;
+      })
+      .then(() => {
+        coordinator.play();
+        return new Promise((resolve) => {
+          const transportChange = (state) => {
+            logger.debug(`Player changed to state ${state.playbackState}`);
+            if (state.playbackState === 'STOPPED') {
+              return resolve();
+            }
+
+            coordinator.once('transport-state', transportChange);
+          };
+          setTimeout(() => {
+            coordinator.once('transport-state', transportChange);
+          }, duration / 2);
+
+          logger.debug(`Setting restore timer for ${restoreTimeout} ms`);
+          abortTimer = setTimeout(resolve, restoreTimeout);
+        });
+      })
+      .then(() => {
+        clearTimeout(abortTimer);
+      })
+      .then(() => {
+        return backupPresets.reduce((promise, preset) => {
+          logger.trace('Restoring preset', preset);
+          return promise.then(() => system.applyPreset(preset));
+        }, Promise.resolve());
+      })
+      .catch((err) => {
+        logger.error(err.stack);
+        throw err;
+      });
+  }
+}
+
+function allPresetsRestored() {
+  announceAllActive = null;
 }
 
 module.exports = announceAll;

--- a/settings.js
+++ b/settings.js
@@ -24,6 +24,11 @@ var settings = {
   announceVolume: 40
 };
 
+// manage concurrent 'xxxall' actions
+global.restrictParallelAnnouncements = true;  // True discards parallel requests to the helper 'all-player-announcement'
+global.announceAllActive = null;              // Timer tag also used to detect an active timer
+global.systemGroupUngroupDuration = 10000;    // milliseconds, approx time for the system to form one group and return to the original state
+
 // load user settings
 const settingsFileFullPath = path.resolve(__dirname, 'settings.json');
 const userSettings = tryLoadJson(settingsFileFullPath);


### PR DESCRIPTION
Concurrent clipall/sayall can leave the system in an undefined state if the second action is processed while the system is in a partially grouped state. An example is clipall/sayall being used with a doorbell and someone pressing the doorbell button twice.

This feature implements a check within all-player-announcements. Calls to the helper will start a timer and, if restricted, subsequent calls will be ignored while the timer is active.
This allows time for the original state to be restored before the next clipall/sayall action.

Global variables are possibly not the best implementation, but none of the existing helper files require settings.js so this change did not introduce a require settings.js to all-player-announcements.

The auto changes look larger than actual changes to all-player-announcements, in summary:
if NOT (restricted AND current active announcement) {
  start timer and use timer handle to track an active announcement
  existing code
}
function (timer expiry) {
  null the timer handle
}