### PR TITLE
adding addtoqueue API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The actions supported as of today:
 * saypreset
 * queue
 * clearqueue
+* addtoqueue
 * sleep (values in seconds)
 * linein (only analog linein, not PLAYBAR yet)
 * clip (announce custom mp3 clip)
@@ -184,6 +185,25 @@ Example queue response:
 
 ```
 
+addtoqueue (beta)
+-----
+Add track to the current queue of specified player. You can obtain track uri from /favorites/detailed call. When using Sonos music library (CIFS) and know the path of a song you can construct the uri by using encodeURIComponent. The request will accept:
+ - uri (required, 
+ - enqueueAsNext (boolean, required)
+ - desiredFirstTrackNumberEnqueued (optional)
+
+	    http://localhost:5005/living room/addtoqueue/x-file-cifs%3A%2F%2F10.10.1.77%2Fpublic%2FJames%20Bond%20Soundtracks%2F02.%20From%20Russia%20With%20Love%2F07%20-%20007.mp3/true/1
+	    http://localhost:5005/living room/addtoqueue/x-sonos-spotify:spotify%3atrack%3a4BggEwLhGfrbrl7JBhC8EC?sid=9&flags=8224&sn=2/true/1
+
+addtoqueue works with Sonos music library (CIFS) and works partially with Spotify. Added songs from Spotify will display correct album art, but display song id instead of song title. 
+
+Example queue response:
+```
+[
+    {"firsttracknumberenqueued":"4","numtracksadded":"1","newqueuelength":"4"}
+]
+
+```
 
 Preset
 ------

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Add track to the current queue of specified player. You can obtain track uri fro
 
 addtoqueue works with Sonos music library (CIFS) and works partially with Spotify. Added songs from Spotify will display correct album art, but display song id instead of song title. 
 
-Example queue response:
+Example addtoqueue response:
 ```
 [
     {"firsttracknumberenqueued":"4","numtracksadded":"1","newqueuelength":"4"}

--- a/lib/actions/addToQueue.js
+++ b/lib/actions/addToQueue.js
@@ -1,0 +1,13 @@
+'use strict';
+
+function addtoqueue(player, values) {
+  const uri = decodeURIComponent(values[0]);
+  const enqueueAsNext = values[1];
+  const desiredFirstTrackNumberEnqueued = values[2];
+  const metadata = "";
+  return player.coordinator.addURIToQueue(uri, metadata, enqueueAsNext, desiredFirstTrackNumberEnqueued);
+}
+
+module.exports = function (api) {
+  api.registerAction('addtoqueue', addtoqueue);
+};


### PR DESCRIPTION
**addtoqueue (beta)**

Add track to the current queue of specified player. You can obtain track uri from /favorites/detailed call. When using Sonos music library (CIFS) and know the path of a song you can construct the uri by using encodeURIComponent. The request will accept:

- uri (required, 
- enqueueAsNext (boolean, required)
- desiredFirstTrackNumberEnqueued (optional)

Examples:

- http://localhost:5005/living room/addtoqueue/x-file-cifs%3A%2F%2F10.10.1.77%2Fpublic%2FJames%20Bond%20Soundtracks%2F02.%20From%20Russia%20With%20Love%2F07%20-%20007.mp3/true/1
- http://localhost:5005/living room/addtoqueue/x-sonos-spotify:spotify%3atrack%3a4BggEwLhGfrbrl7JBhC8EC?sid=9&flags=8224&sn=2/true/1

addtoqueue works with Sonos music library (CIFS) and works partially with Spotify. Added songs from Spotify will display correct album art, but display song id instead of song title. 

Example addtoqueue response:

```
[
    {"firsttracknumberenqueued":"4","numtracksadded":"1","newqueuelength":"4"}
]
```

Feedback on how to fix the song title for Spotify is welcome. There should be a way to specify the metadata in the player.coordinator.addURIToQueue call. But have not found a good way for it yet.