### PR TITLE
New endpoint to show if any speaker is running

### DIFF
--- a/lib/actions/pauseall.js
+++ b/lib/actions/pauseall.js
@@ -80,5 +80,5 @@ function doAnyPlayerOn(system) {
 module.exports = function (api) {
   api.registerAction('pauseall', pauseAll);
   api.registerAction('resumeall', resumeAll);
-  api.registerAction('stateon', anyPlayerOn);
+  api.registerAction('anyplayeron', anyPlayerOn);
 }

--- a/lib/actions/pauseall.js
+++ b/lib/actions/pauseall.js
@@ -58,8 +58,27 @@ function doResumeAll(system) {
   return Promise.all(promises);
 }
 
+function anyPlayerOn(player, values) {
+  logger.debug("is any player on");
+
+  if (values[0] && values[0] > 0) {
+    setTimeout(function () {
+      doStateOn(player.system);
+    }, values[0] * 1000 * 60);
+    return Promise.resolve();
+  }
+
+  return doAnyPlayerOn(player.system);
+}
+
+function doAnyPlayerOn(system) {
+  const promises = system.zones.some(zone => zone.coordinator.state.playbackState === 'PLAYING');
+  return {promises};
+}
+
 
 module.exports = function (api) {
   api.registerAction('pauseall', pauseAll);
   api.registerAction('resumeall', resumeAll);
+  api.registerAction('stateon', anyPlayerOn);
 }

--- a/static/index.html
+++ b/static/index.html
@@ -32,6 +32,7 @@
         <p><span class="method">GET</span> <a href="/zones">/zones</a></p>
         <p><span class="method">GET</span> <a href="/favorites">/favorites</a></p>
         <p><span class="method">GET</span> <a href="/playlists">/playlists</a></p>
+        <p><span class="method">GET</span> <a href="/anyplayeron">/anyplayeron</a></p>
       </div>
 
       <div class="docs">


### PR DESCRIPTION
To be able to show if any speaker is running (e.g in Apple Home Kit as a Switch) created a new endpoint which returns true if any speaker has the playBackState === "PLAYING" otherwise return false.

With the new endpoint it is possible together with homebride and the hombridge-http-switch plugin to stop all speakers from Apple Home Kit. The new endpoint is needed to display the state of the button. So if a speaker is running turn switch on otherwise turn switch off.

```
{
     "accessory": "HTTP-SWITCH",
     "name": "Sonos",
     "switchType": "stateful",
     "timeout": 3000,
     "offUrl": "http://localhost:5005/pauseall",
     "onUrl": "http://localhost:5005/resumeall",
     "statusUrl": "http://localhost:5005/anyplayeron",
     "statusPattern": "{\"anyOn\":true}"
}
```