### PR TITLE
Update spotify/now/album|playlist to always set AVtransport to queue

### DIFF
--- a/lib/actions/spotify.js
+++ b/lib/actions/spotify.js
@@ -29,15 +29,10 @@ function spotify(player, values) {
   } else if (action == 'now') {
     var nextTrackNo = player.coordinator.state.trackNo + 1;
     let promise = Promise.resolve();
-    if (player.coordinator.avTransportUri.startsWith('x-rincon-queue') === false) {
-      promise = promise.then(() => player.coordinator.setAVTransport(`x-rincon-queue:${player.coordinator.uuid}#0`));
-    }
-
-    return promise.then(() => {
-      return player.coordinator.addURIToQueue(uri, metadata, true, nextTrackNo)
-        .then((addToQueueStatus) => player.coordinator.trackSeek(addToQueueStatus.firsttracknumberenqueued))
-        .then(() => player.coordinator.play());
-    });
+    return promise.then(() => player.coordinator.setAVTransport(`x-rincon-queue:${player.coordinator.uuid}#0`))
+    .then(() => player.coordinator.addURIToQueue(uri, metadata, true, nextTrackNo))
+    .then((addToQueueStatus) => player.coordinator.trackSeek(addToQueueStatus.firsttracknumberenqueued))
+    .then(() => player.coordinator.play());
 
   } else if (action == 'next') {
     var nextTrackNo = player.coordinator.state.trackNo + 1;


### PR DESCRIPTION
I could not get the existing code to properly update the AVtransport to queue, meaning I had the same problem as originally described in issue #390. Forcing the Spotify action to always set this, even if it might already be correct, fixes my problem and doesn't seem to introduce any trouble as far as I can see.