### PR TITLE
Update to README.md to clarify services need to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -786,7 +786,9 @@ Switch "placement adjustment" or more commonly known as phase. 0 = 0Â°, 1 = 180Â
 Spotify, Apple Music and Amazon Music (Experimental)
 ----------------------
 
-Allows you to perform your own external searches for Apple Music or Spotify songs or albums and play a specified song or track ID. The Music Search funtionality outlined further below performs a search of its own and plays the specified music.
+Allows you to perform your own external searches for Spotify, Apple Music or Amazon Music songs or albums and play a specified song or track ID. The Music Search funtionality outlined further below performs a search of its own and plays the specified music.
+
+Ensure you have added and registered the respective service with your Sonos account, before trying to control your speakers with node-sonos-http-api. Instructions on how to do this can be found here: https://support.sonos.com/s/article/2757?language=en_US
 
 The following endpoints are available:
 
@@ -851,8 +853,10 @@ The format is: https://music.amazon.de/albums/{albumID}?trackAsin={songID}&ref=d
 The format is: https://music.amazon.de/albums/{albumID}?ref=dm_sh_97aa-255b-dmcp-c6ba-4ff00&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
 > eg: https://music.amazon.de/albums/B0727SH7LW?ref=dm_sh_97aa-255b-dmcp-c6ba-4ff00&musicTerritory=DE&marketplaceId=A1PA6795UKMFR9
 
-BBC Sounds
+BBC Sounds (as of 2022 only available in the UK)
 ----------------------
+Ensure you have added and registered the BBC Sounds service with your Sonos account, before trying to control your speakers with node-sonos-http-api. Instructions on how to do this can be found here: https://www.bbc.co.uk/sounds/help/questions/listening-on-a-smart-speaker/sonos or here: https://support.sonos.com/s/article/2757?language=en_US
+
 You can specify a BBC station and the station will be played or set depending on the command used.
 
 To play immediately:


### PR DESCRIPTION
Added clarity that the services need to be installed in the SONOS account for node-sonos-http-api to be able control them.
Added clarity that the BBC Sounds service is only available in the UK