### PR TITLE
Add HTTP event source endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,31 @@ or
 "data" property will be equal to the same data as you would get from /RoomName/state or /zones. There is an example endpoint in the root if this project called test_endpoint.js which you may fire up to get an understanding of what is posted, just invoke it with "node test_endpoint.js" in a terminal, and then start the http-api in another terminal.
 
 
+Server Sent Events
+-----
+
+As an alternative to the web hook you can also call the `/events` endpoint to receive every state change and topology change as [Server Sent Event](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events).
+Compared to the web hook there is no configuration required on the server, and you can listen for events from multiple clients.
+
+Because it is a long-polling connection, you must take care of errors in your client code and re-connect if necessary.
+
+The server sends events formatted as single-line JSON in the format of Server Sent Events: every event starts with the string `data: `, followed by the single-line JSON formatted event, and is terminated by two new line characters.
+
+There are [several client libraries available](https://en.wikipedia.org/wiki/Server-sent_events#Libraries) to listen for Server Sent Events.
+Using `curl` yields the following output for some volume changes:
+
+```shell
+host:~ user$ curl localhost:5005/events
+data: {"type":"volume-change","data":{"uuid":"RINCON_E2832F58D9074C45B","previousVolume":13,"newVolume":19,"roomName":"Office"}}
+
+data: {"type":"volume-change","data":{"uuid":"RINCON_E2832F58D9074C45B","previousVolume":19,"newVolume":25,"roomName":"Office"}}
+
+data: {"type":"volume-change","data":{"uuid":"RINCON_E2832F58D9074C45B","previousVolume":25,"newVolume":24,"roomName":"Office"}}
+
+data: {"type":"volume-change","data":{"uuid":"RINCON_E2832F58D9074C45B","previousVolume":23,"newVolume":23,"roomName":"Office"}}
+
+```
+
 DOCKER
 -----
 

--- a/lib/helpers/http-event-server.js
+++ b/lib/helpers/http-event-server.js
@@ -1,0 +1,19 @@
+function HttpEventServer() {
+    let clients = [];
+
+    const removeClient = client => clients = clients.filter(value => value !== client);
+
+    this.addClient = res => clients.push(new HttpEventSource(res, removeClient));
+
+    this.sendEvent = event => clients.forEach(client => client.sendEvent(event))
+}
+
+function HttpEventSource(res, done) {
+    this.sendEvent = event => res.write('data: ' + event + '\n\n')
+
+    res.on('close', () => done(this))
+
+    res.setHeader('Content-Type', 'text/event-stream');
+}
+
+module.exports = HttpEventServer;

--- a/lib/sonos-http-api.js
+++ b/lib/sonos-http-api.js
@@ -9,6 +9,7 @@ function HttpAPI(discovery, settings) {
   const port = settings.port;
   const webroot = settings.webroot;
   const actions = {};
+  const events = new HttpEventServer();
 
   this.getWebRoot = function () {
     return webroot;
@@ -49,6 +50,11 @@ function HttpAPI(discovery, settings) {
   this.requestHandler = function (req, res) {
     if (req.url === '/favicon.ico') {
       res.end();
+      return;
+    }
+
+    if (req.url === '/events') {
+      events.addClient(res);
       return;
     }
 
@@ -122,7 +128,6 @@ function HttpAPI(discovery, settings) {
   function invokeWebhook(type, data) {
     var typeName = "type";
     var dataName = "data";
-    if (!settings.webhook) return;
 
     if (settings.webhookType) { typeName = settings.webhookType; }
     if (settings.webhookData) { dataName = settings.webhookData; }
@@ -131,6 +136,10 @@ function HttpAPI(discovery, settings) {
       [typeName]: type,
       [dataName]: data
     });
+
+    events.sendEvent(jsonBody);
+
+    if (!settings.webhook) return;
 
     const body = new Buffer(jsonBody, 'utf8');
 
@@ -154,6 +163,24 @@ function HttpAPI(discovery, settings) {
     })
   }
 
+}
+
+function HttpEventServer() {
+  let clients = [];
+
+  const removeClient = client => clients = clients.filter(value => value !== client);
+
+  this.addClient = res => clients.push(new HttpEventSource(res, removeClient));
+
+  this.sendEvent = event => clients.forEach(client => client.sendEvent(event))
+}
+
+function HttpEventSource(res, done) {
+  this.sendEvent = event => res.write('data: ' + event + '\n\n')
+
+  res.on('close', () => done(this))
+
+  res.setHeader('Content-Type', 'text/event-stream');
 }
 
 module.exports = HttpAPI;

--- a/lib/sonos-http-api.js
+++ b/lib/sonos-http-api.js
@@ -3,6 +3,7 @@ const requireDir = require('./helpers/require-dir');
 const path = require('path');
 const request = require('sonos-discovery/lib/helpers/request');
 const logger = require('sonos-discovery/lib/helpers/logger');
+const HttpEventServer = require('./helpers/http-event-server');
 
 function HttpAPI(discovery, settings) {
 
@@ -163,24 +164,6 @@ function HttpAPI(discovery, settings) {
     })
   }
 
-}
-
-function HttpEventServer() {
-  let clients = [];
-
-  const removeClient = client => clients = clients.filter(value => value !== client);
-
-  this.addClient = res => clients.push(new HttpEventSource(res, removeClient));
-
-  this.sendEvent = event => clients.forEach(client => client.sendEvent(event))
-}
-
-function HttpEventSource(res, done) {
-  this.sendEvent = event => res.write('data: ' + event + '\n\n')
-
-  res.on('close', () => done(this))
-
-  res.setHeader('Content-Type', 'text/event-stream');
 }
 
 module.exports = HttpAPI;


### PR DESCRIPTION
This pull requests adds a new endpoint `/events` serving status updates as Server Side Events analogous to the webhook mechanism.

It improves upon the webhook mechanism, because multiple clients can connect to the server simultaneously to receive updates, and there is no server configuration required to define the target.

Server Side Events can be consumed by Browser JavaScript using the [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) class. It's also possible to just use a plain HTTP client like `curl` to subscribe to the updates, eg `curl localhost:5005/events`.