### PR TITLE
Enhanced debugging features:

### DIFF
--- a/lib/sonos-http-api.js
+++ b/lib/sonos-http-api.js
@@ -67,7 +67,27 @@ function HttpAPI(discovery, settings) {
     }
 
     const params = req.url.substring(1).split('/');
-    
+
+    // Change node environment log level on request. 
+    if (/^\/loglevel\/.+$/.test(req.url)) {
+        let param = params[1];
+        switch (param) {
+        case 'off':
+            param = 'error';
+        case 'trace':
+        case 'debug':
+        case 'info':
+        case 'warn':
+        case 'error':
+            process.env.NODE_LOG_LEVEL = params[1];
+            sendResponse(200, { loglevel: param });
+            break;
+        default:
+            sendResponse(500, { error: `${param} is not a log level` });
+        }
+        return;
+    }
+
     // parse decode player name considering decode errors
     let player;
     try {

--- a/server.js
+++ b/server.js
@@ -14,7 +14,8 @@ const discovery = new SonosSystem(settings);
 const api = new SonosHttpAPI(discovery, settings);
 
 var requestHandler = function (req, res) {
-  req.addListener('end', function () {
+    logger.debug(`request: ${req.url}`);
+    req.addListener('end', function () {
     fileServer.serve(req, res, function (err) {
 
       // If error, route it.

--- a/static/index.html
+++ b/static/index.html
@@ -44,6 +44,7 @@
         <p><span class="method">GET</span> /sleep/{timeout in seconds or timestamp HH:MM:SS or off}</p>
         <p><span class="method">GET</span> /preset/{JSON preset}</p>
         <p><span class="method">GET</span> /preset/{predefined preset name}</p>
+        <p><span class="method">GET</span> /loglevel/{trace|debug|info|warn|error|off}}</p>
       </div>
 
       <div class="docs">


### PR DESCRIPTION
1. Log request uri in server request handler for log level debug. I prefer to log this level info in mny fork because it enables quick diagnosis when my Alexa speech skill has misheard what I said. But doing it on debug level is more consistent with the original program.

2. Add /loglevel get request which implements ability to change the process NODE_LOG_LEVEL (one of trace, debug, info, warn, or error (and off which is a synonym for error)). Document the command in static doc content.

This is very useful when the code is running in a container. Especially if you add it to your alexa skill as I have.