### PR TITLE
Update preset-announcement.js to skip restore of idle players

### DIFF
--- a/lib/helpers/preset-announcement.js
+++ b/lib/helpers/preset-announcement.js
@@ -2,35 +2,44 @@
 const logger = require('sonos-discovery/lib/helpers/logger');
 const isRadioOrLineIn = require('../helpers/is-radio-or-line-in');
 
-function saveAll(system) {
+function savePresetPlayers(system, pset) {
   const backupPresets = system.zones.map((zone) => {
     const coordinator = zone.coordinator;
     const state = coordinator.state;
-    const preset = {
-      players: [
-        { roomName: coordinator.roomName, volume: state.volume }
-      ],
-      state: state.playbackState,
-      uri: coordinator.avTransportUri,
-      metadata: coordinator.avTransportUriMetadata,
-      playMode: {
-        repeat: state.playMode.repeat
+    for (var index = 0; index < pset.players.length; ++index) {
+			if (pset.players[index].roomName == coordinator.roomName) {
+        const preset = {
+          players: [
+            { roomName: coordinator.roomName, volume: state.volume }
+          ],
+          state: state.playbackState,
+          uri: coordinator.avTransportUri,
+          metadata: coordinator.avTransportUriMetadata,
+          playMode: {
+            repeat: state.playMode.repeat
+          }
+        };
+
+        if (!isRadioOrLineIn(preset.uri)) {
+          preset.trackNo = state.trackNo;
+          preset.elapsedTime = state.elapsedTime;
+        }
+
+        zone.members.forEach(function (player) {
+          if (coordinator.uuid != player.uuid)
+            preset.players.push({ roomName: player.roomName, volume: player.state.volume });
+        });
+
+        return preset;
       }
-    };
-
-    if (!isRadioOrLineIn(preset.uri)) {
-      preset.trackNo = state.trackNo;
-      preset.elapsedTime = state.elapsedTime;
     }
-
-    zone.members.forEach(function (player) {
-      if (coordinator.uuid != player.uuid)
-        preset.players.push({ roomName: player.roomName, volume: player.state.volume });
-    });
-
-    return preset;
-
   });
+
+  Object.keys(backupPresets).forEach(key => {
+		if (backupPresets[key] === undefined) {
+			delete backupPresets[key];
+		}
+	});
 
   logger.trace('backup presets', backupPresets);
   return backupPresets.sort((a, b) => {
@@ -41,9 +50,6 @@ function saveAll(system) {
 function announcePreset(system, uri, preset, duration) {
   let abortTimer;
 
-  // Save all players
-  var backupPresets = saveAll(system);
-
   const simplifiedPreset = {
     uri,
     players: preset.players,
@@ -51,6 +57,8 @@ function announcePreset(system, uri, preset, duration) {
     pauseOthers: true,
     state: 'STOPPED'
   };
+
+  var backupPresets = savePresetPlayers(system,preset);
 
   function hasReachedCorrectTopology(zones) {
     return zones.some(group =>


### PR DESCRIPTION
When using presets all players get backup/restore. This affects a playing player by restoring it to the time of backup state.elapsedTime, even if this player is not included in the preset file and is supposed to be skipped. Even if pauseOthers is set to false, by this behavior the player still get interrupted one sec because it is shifted back to recorded elapsedTime.

This PR is changing "saveAll" to "savePresetPlayers" and will backup/restore only players specified in preset file. Idle players are no more affected by running presets.

Tested and found more stable when joining/leaving groups after tts or chime clips.