### PR TITLE
Include baseUrl in /zones API response

### DIFF
--- a/lib/actions/zones.js
+++ b/lib/actions/zones.js
@@ -7,7 +7,8 @@ function simplifyPlayer(player) {
     playMode: player.currentPlayMode,
     roomName: player.roomName,
     coordinator: player.coordinator.uuid,
-    groupState: player.groupState
+    groupState: player.groupState,
+    baseUrl: player.baseUrl
   };
 }
 


### PR DESCRIPTION
Add baseUrl property to simplifyPlayer output so device IP addresses are available in the zones endpoint response. 

I needed this for my project backstage (https://github.com/jasona/backstage).

Thanks for an amazing library!